### PR TITLE
feat(auth): support api-token for instill cloud authentication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,12 +36,7 @@ jobs:
 
     - name: Test code
       run: make test
-
-    - name: check coverage
-      run: |
-        ls -la .cache
-        ls -la coverage.xml
-
+gi
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Test code
       run: make test
-gi
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/instill_sdk/clients/client.py
+++ b/instill_sdk/clients/client.py
@@ -1,6 +1,8 @@
 # pylint: disable=no-member,wrong-import-position
 from abc import ABC, abstractmethod
+import os
 
+API_TOKEN = os.environ.get("INSTILL_AI_API_TOKEN", default="")
 
 class Client(ABC):
     """Base interface class for creating mgmt/pipeline/connector/model clients.

--- a/instill_sdk/clients/client.py
+++ b/instill_sdk/clients/client.py
@@ -1,8 +1,9 @@
 # pylint: disable=no-member,wrong-import-position
-from abc import ABC, abstractmethod
 import os
+from abc import ABC, abstractmethod
 
 API_TOKEN = os.environ.get("INSTILL_AI_API_TOKEN", default="")
+
 
 class Client(ABC):
     """Base interface class for creating mgmt/pipeline/connector/model clients.

--- a/instill_sdk/clients/client.py
+++ b/instill_sdk/clients/client.py
@@ -11,12 +11,12 @@ class Client(ABC):
 
     @property
     @abstractmethod
-    def protocol(self):
+    def token(self):
         pass
 
-    @protocol.setter
+    @token.setter
     @abstractmethod
-    def protocol(self):
+    def token(self):
         pass
 
     @property

--- a/instill_sdk/clients/connector.py
+++ b/instill_sdk/clients/connector.py
@@ -6,7 +6,7 @@ import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_pb2 as connector_interface
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_public_service_pb2_grpc as connector_service
-from instill_sdk.clients.client import Client
+from instill_sdk.clients.client import Client, API_TOKEN
 from instill_sdk.utils.error_handler import grpc_handler
 
 # from instill_sdk.utils.logger import Logger
@@ -14,7 +14,7 @@ from instill_sdk.utils.error_handler import grpc_handler
 
 class ConnectorClient(Client):
     def __init__(
-        self, user: mgmt_interface.User, token="", host="localhost", port="8080"
+        self, user: mgmt_interface.User, token=API_TOKEN, host="localhost", port="8080"
     ) -> None:
         """Initialize client for connector service with target host.
 

--- a/instill_sdk/clients/connector.py
+++ b/instill_sdk/clients/connector.py
@@ -6,7 +6,7 @@ import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_pb2 as connector_interface
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_public_service_pb2_grpc as connector_service
-from instill_sdk.clients.client import Client, API_TOKEN
+from instill_sdk.clients.client import API_TOKEN, Client
 from instill_sdk.utils.error_handler import grpc_handler
 
 # from instill_sdk.utils.logger import Logger

--- a/instill_sdk/clients/connector.py
+++ b/instill_sdk/clients/connector.py
@@ -14,33 +14,40 @@ from instill_sdk.utils.error_handler import grpc_handler
 
 class ConnectorClient(Client):
     def __init__(
-        self, user: mgmt_interface.User, protocol="http", host="localhost", port="8080"
+        self, user: mgmt_interface.User, token="", host="localhost", port="8080"
     ) -> None:
         """Initialize client for connector service with target host.
 
         Args:
-            protocol (str): http/https
+            token (str): api token for authentication
             host (str): host url
             port (str): host port
         """
 
-        self.protocol = protocol
+        self.token = token
         self.host = host
         self.port = port
 
         self._user = user
-        self._channel = grpc.insecure_channel(
-            f"{host}:{port}".format(protocol=protocol, host=host, port=port)
-        )
+        if len(token) == 0:
+            self._channel = grpc.insecure_channel(f"{host}:{port}")
+        else:
+            ssl_creds = grpc.ssl_channel_credentials()
+            call_creds = grpc.access_token_call_credentials(token)
+            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+            self._channel = grpc.secure_channel(
+                target=f"{host}",
+                credentials=creds,
+            )
         self._stub = connector_service.ConnectorPublicServiceStub(self._channel)
 
     @property
-    def protocol(self):
-        return self._protocol
+    def token(self):
+        return self._token
 
-    @protocol.setter
-    def protocol(self, protocol: str):
-        self._protocol = protocol
+    @token.setter
+    def token(self, token: str):
+        self._token = token
 
     @property
     def host(self):

--- a/instill_sdk/clients/mgmt.py
+++ b/instill_sdk/clients/mgmt.py
@@ -5,14 +5,14 @@ import instill_sdk.protogen.base.mgmt.v1alpha.metric_pb2 as metric_interface
 import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
-from instill_sdk.clients.client import Client
+from instill_sdk.clients.client import Client, API_TOKEN
 from instill_sdk.utils.error_handler import grpc_handler
 
 # from instill_sdk.utils.logger import Logger
 
 
 class MgmtClient(Client):
-    def __init__(self, token="", host="localhost", port="7080") -> None:
+    def __init__(self, token=API_TOKEN, host="localhost", port="7080") -> None:
         """Initialize client for management service with target host.
 
         Args:

--- a/instill_sdk/clients/mgmt.py
+++ b/instill_sdk/clients/mgmt.py
@@ -12,31 +12,38 @@ from instill_sdk.utils.error_handler import grpc_handler
 
 
 class MgmtClient(Client):
-    def __init__(self, protocol="http", host="localhost", port="7080") -> None:
+    def __init__(self, token="", host="localhost", port="7080") -> None:
         """Initialize client for management service with target host.
 
         Args:
-            protocol (str): http/https
+            token (str): api token for authentication
             host (str): host url
             port (str): host port
         """
 
-        self.protocol = protocol
+        self.token = token
         self.host = host
         self.port = port
 
-        self._channel = grpc.insecure_channel(
-            f"{host}:{port}".format(protocol=protocol, host=host, port=port)
-        )
+        if len(token) == 0:
+            self._channel = grpc.insecure_channel(f"{host}:{port}")
+        else:
+            ssl_creds = grpc.ssl_channel_credentials()
+            call_creds = grpc.access_token_call_credentials(token)
+            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+            self._channel = grpc.secure_channel(
+                target=f"{host}",
+                credentials=creds,
+            )
         self._stub = mgmt_service.MgmtPublicServiceStub(self._channel)
 
     @property
-    def protocol(self):
-        return self._protocol
+    def token(self):
+        return self._token
 
-    @protocol.setter
-    def protocol(self, protocol: str):
-        self._protocol = protocol
+    @token.setter
+    def token(self, token: str):
+        self._token = token
 
     @property
     def host(self):

--- a/instill_sdk/clients/mgmt.py
+++ b/instill_sdk/clients/mgmt.py
@@ -5,7 +5,7 @@ import instill_sdk.protogen.base.mgmt.v1alpha.metric_pb2 as metric_interface
 import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
-from instill_sdk.clients.client import Client, API_TOKEN
+from instill_sdk.clients.client import API_TOKEN, Client
 from instill_sdk.utils.error_handler import grpc_handler
 
 # from instill_sdk.utils.logger import Logger

--- a/instill_sdk/clients/model.py
+++ b/instill_sdk/clients/model.py
@@ -12,13 +12,13 @@ import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as health
 # model
 import instill_sdk.protogen.model.model.v1alpha.model_pb2 as model_interface
 import instill_sdk.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
-from instill_sdk.clients.client import Client
+from instill_sdk.clients.client import Client, API_TOKEN
 from instill_sdk.utils.error_handler import grpc_handler
 
 
 class ModelClient(Client):
     def __init__(
-        self, user: mgmt_interface.User, token="", host="localhost", port="9080"
+        self, user: mgmt_interface.User, token=API_TOKEN, host="localhost", port="9080"
     ) -> None:
         """Initialize client for model service with target host.
 

--- a/instill_sdk/clients/model.py
+++ b/instill_sdk/clients/model.py
@@ -18,33 +18,40 @@ from instill_sdk.utils.error_handler import grpc_handler
 
 class ModelClient(Client):
     def __init__(
-        self, user: mgmt_interface.User, protocol="http", host="localhost", port="9080"
+        self, user: mgmt_interface.User, token="", host="localhost", port="9080"
     ) -> None:
         """Initialize client for model service with target host.
 
         Args:
-            protocol (str): http/https
+            token (str): api token for authentication
             host (str): host url
             port (str): host port
         """
 
-        self.protocol = protocol
+        self.token = token
         self.host = host
         self.port = port
 
         self._user = user
-        self._channel = grpc.insecure_channel(
-            f"{host}:{port}".format(protocol=protocol, host=host, port=port)
-        )
+        if len(token) == 0:
+            self._channel = grpc.insecure_channel(f"{host}:{port}")
+        else:
+            ssl_creds = grpc.ssl_channel_credentials()
+            call_creds = grpc.access_token_call_credentials(token)
+            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+            self._channel = grpc.secure_channel(
+                target=f"{host}",
+                credentials=creds,
+            )
         self._stub = model_service.ModelPublicServiceStub(self._channel)
 
     @property
-    def protocol(self):
-        return self._protocol
+    def token(self):
+        return self._token
 
-    @protocol.setter
-    def protocol(self, protocol: str):
-        self._protocol = protocol
+    @token.setter
+    def token(self, token: str):
+        self._token = token
 
     @property
     def host(self):

--- a/instill_sdk/clients/model.py
+++ b/instill_sdk/clients/model.py
@@ -12,7 +12,7 @@ import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as health
 # model
 import instill_sdk.protogen.model.model.v1alpha.model_pb2 as model_interface
 import instill_sdk.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
-from instill_sdk.clients.client import Client, API_TOKEN
+from instill_sdk.clients.client import API_TOKEN, Client
 from instill_sdk.utils.error_handler import grpc_handler
 
 

--- a/instill_sdk/clients/pipeline.py
+++ b/instill_sdk/clients/pipeline.py
@@ -14,7 +14,7 @@ import instill_sdk.protogen.vdp.pipeline.v1alpha.pipeline_pb2 as pipeline_interf
 import instill_sdk.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
 
 # common
-from instill_sdk.clients.client import Client, API_TOKEN
+from instill_sdk.clients.client import API_TOKEN, Client
 from instill_sdk.utils.error_handler import grpc_handler
 
 

--- a/instill_sdk/clients/pipeline.py
+++ b/instill_sdk/clients/pipeline.py
@@ -20,33 +20,40 @@ from instill_sdk.utils.error_handler import grpc_handler
 
 class PipelineClient(Client):
     def __init__(
-        self, user: mgmt_interface.User, protocol="http", host="localhost", port="8080"
+        self, user: mgmt_interface.User, token="", host="localhost", port="8080"
     ) -> None:
         """Initialize client for pipeline service with target host.
 
         Args:
-            protocol (str): http/https
+            token (str): api token for authentication
             host (str): host url
             port (str): host port
         """
 
-        self.protocol = protocol
+        self.token = token
         self.host = host
         self.port = port
 
         self._user = user
-        self._channel = grpc.insecure_channel(
-            f"{host}:{port}".format(protocol=protocol, host=host, port=port)
-        )
+        if len(token) == 0:
+            self._channel = grpc.insecure_channel(f"{host}:{port}")
+        else:
+            ssl_creds = grpc.ssl_channel_credentials()
+            call_creds = grpc.access_token_call_credentials(token)
+            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+            self._channel = grpc.secure_channel(
+                target=f"{host}",
+                credentials=creds,
+            )
         self._stub = pipeline_service.PipelinePublicServiceStub(self._channel)
 
     @property
-    def protocol(self):
-        return self._protocol
+    def token(self):
+        return self._token
 
-    @protocol.setter
-    def protocol(self, protocol: str):
-        self._protocol = protocol
+    @token.setter
+    def token(self, token: str):
+        self._token = token
 
     @property
     def host(self):

--- a/instill_sdk/clients/pipeline.py
+++ b/instill_sdk/clients/pipeline.py
@@ -14,13 +14,13 @@ import instill_sdk.protogen.vdp.pipeline.v1alpha.pipeline_pb2 as pipeline_interf
 import instill_sdk.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
 
 # common
-from instill_sdk.clients.client import Client
+from instill_sdk.clients.client import Client, API_TOKEN
 from instill_sdk.utils.error_handler import grpc_handler
 
 
 class PipelineClient(Client):
     def __init__(
-        self, user: mgmt_interface.User, token="", host="localhost", port="8080"
+        self, user: mgmt_interface.User, token=API_TOKEN, host="localhost", port="8080"
     ) -> None:
         """Initialize client for pipeline service with target host.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,30 +33,30 @@ def describe_client():
             connector_client.host = "instill"
             expect(connector_client.host) == "instill"
 
-    def describe_protocol():
+    def describe_token():
         def when_not_set(expect):
             mgmt_client = MgmtClient()
-            expect(mgmt_client.protocol) == "http"
+            expect(mgmt_client.token) == ""
             model_client = ModelClient(user=mgmt_client.get_user())
-            expect(model_client.protocol) == "http"
+            expect(model_client.token) == ""
             pipeline_client = PipelineClient(user=mgmt_client.get_user())
-            expect(pipeline_client.protocol) == "http"
+            expect(pipeline_client.token) == ""
             connector_client = ConnectorClient(user=mgmt_client.get_user())
-            expect(connector_client.protocol) == "http"
+            expect(connector_client.token) == ""
 
         def when_set_correct_type(expect):
             mgmt_client = MgmtClient()
-            mgmt_client.protocol = "instill"
-            expect(mgmt_client.protocol) == "instill"
+            mgmt_client.token = "instill"
+            expect(mgmt_client.token) == "instill"
             model_client = ModelClient(user=mgmt_client.get_user())
-            model_client.protocol = "instill"
-            expect(model_client.protocol) == "instill"
+            model_client.token = "instill"
+            expect(model_client.token) == "instill"
             pipeline_client = PipelineClient(user=mgmt_client.get_user())
-            pipeline_client.protocol = "instill"
-            expect(pipeline_client.protocol) == "instill"
+            pipeline_client.token = "instill"
+            expect(pipeline_client.token) == "instill"
             connector_client = ConnectorClient(user=mgmt_client.get_user())
-            connector_client.protocol = "instill"
-            expect(connector_client.protocol) == "instill"
+            connector_client.token = "instill"
+            expect(connector_client.token) == "instill"
 
     def describe_port():
         def when_not_set(expect):


### PR DESCRIPTION
Because

- allow users to authenticate with api-token for instill cloud

This commit

- add support for api-token header
