### PR TITLE
ci(workflows): add lint reusable workflow

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate PR title
+    uses: instill-ai/.github/.github/workflows/semantic.yml@fix-reusable-workflow
+    secrets: inherit


### PR DESCRIPTION
Because

- add pr lint workflow

This commit

- add reusable pr lint workflow
