### PR TITLE
refactor(clients): update client interface to support multi instances

### DIFF
--- a/instill_sdk/__main__.py
+++ b/instill_sdk/__main__.py
@@ -3,11 +3,11 @@
 """Package entry point."""
 import pprint
 
-from instill_sdk.configuration import config
+from instill_sdk.configuration import global_config
 
 # from instill_sdk.client import
 
 if __name__ == "__main__":  # pragma: no cover
     # main()  # pylint: disable=no-value-for-parameter
     print("======================Configured Hosts======================")
-    pprint.pprint(config.remotes)
+    pprint.pprint(global_config.hosts)

--- a/instill_sdk/clients/client.py
+++ b/instill_sdk/clients/client.py
@@ -1,8 +1,5 @@
 # pylint: disable=no-member,wrong-import-position
-import os
 from abc import ABC, abstractmethod
-
-API_TOKEN = os.environ.get("INSTILL_AI_API_TOKEN", default="")
 
 
 class Client(ABC):
@@ -14,32 +11,22 @@ class Client(ABC):
 
     @property
     @abstractmethod
-    def token(self):
+    def hosts(self):
         pass
 
-    @token.setter
+    @hosts.setter
     @abstractmethod
-    def token(self):
-        pass
-
-    @property
-    @abstractmethod
-    def host(self):
-        pass
-
-    @host.setter
-    @abstractmethod
-    def host(self):
+    def hosts(self):
         pass
 
     @property
     @abstractmethod
-    def port(self):
+    def instance(self):
         pass
 
-    @port.setter
+    @instance.setter
     @abstractmethod
-    def port(self):
+    def instance(self):
         pass
 
     @abstractmethod

--- a/instill_sdk/clients/connector.py
+++ b/instill_sdk/clients/connector.py
@@ -1,16 +1,18 @@
 # pylint: disable=no-member,wrong-import-position
 from collections import defaultdict
+
 import grpc
 
-# common
-from instill_sdk.configuration import global_config
-from instill_sdk.utils.error_handler import grpc_handler
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 
 # connector
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_pb2 as connector_interface
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_public_service_pb2_grpc as connector_service
 from instill_sdk.clients.client import Client
+
+# common
+from instill_sdk.configuration import global_config
+from instill_sdk.utils.error_handler import grpc_handler
 
 # from instill_sdk.utils.logger import Logger
 
@@ -21,23 +23,24 @@ class ConnectorClient(Client):
         self.instance = "default"
         self.namespace = namespace
 
-        for instance in global_config.hosts.keys():
-            if global_config.hosts[instance].token is None:
-                channel = grpc.insecure_channel(global_config.hosts[instance].url)
-            else:
-                ssl_creds = grpc.ssl_channel_credentials()
-                call_creds = grpc.access_token_call_credentials(
-                    global_config.hosts[instance].token
-                )
-                creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
-                channel = grpc.secure_channel(
-                    target=global_config.hosts[instance].url,
-                    credentials=creds,
-                )
-            self.hosts[instance]["channel"] = channel
-            self.hosts[instance][
-                "client"
-            ] = connector_service.ConnectorPublicServiceStub(channel)
+        if global_config.hosts is not None:
+            for instance in global_config.hosts.keys():
+                if global_config.hosts[instance].token is None:
+                    channel = grpc.insecure_channel(global_config.hosts[instance].url)
+                else:
+                    ssl_creds = grpc.ssl_channel_credentials()
+                    call_creds = grpc.access_token_call_credentials(
+                        global_config.hosts[instance].token
+                    )
+                    creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+                    channel = grpc.secure_channel(
+                        target=global_config.hosts[instance].url,
+                        credentials=creds,
+                    )
+                self.hosts[instance]["channel"] = channel
+                self.hosts[instance][
+                    "client"
+                ] = connector_service.ConnectorPublicServiceStub(channel)
 
     @property
     def hosts(self):

--- a/instill_sdk/clients/connector.py
+++ b/instill_sdk/clients/connector.py
@@ -1,77 +1,71 @@
 # pylint: disable=no-member,wrong-import-position
+from collections import defaultdict
 import grpc
 
-# mgmt
-import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
+# common
+from instill_sdk.configuration import global_config
+from instill_sdk.utils.error_handler import grpc_handler
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
+
+# connector
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_pb2 as connector_interface
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_public_service_pb2_grpc as connector_service
-from instill_sdk.clients.client import API_TOKEN, Client
-from instill_sdk.utils.error_handler import grpc_handler
+from instill_sdk.clients.client import Client
 
 # from instill_sdk.utils.logger import Logger
 
 
 class ConnectorClient(Client):
-    def __init__(
-        self, user: mgmt_interface.User, token=API_TOKEN, host="localhost", port="8080"
-    ) -> None:
-        """Initialize client for connector service with target host.
+    def __init__(self, namespace: str) -> None:
+        self.hosts = defaultdict(dict)
+        self.instance = "default"
+        self.namespace = namespace
 
-        Args:
-            token (str): api token for authentication
-            host (str): host url
-            port (str): host port
-        """
-
-        self.token = token
-        self.host = host
-        self.port = port
-
-        self._user = user
-        if len(token) == 0:
-            self._channel = grpc.insecure_channel(f"{host}:{port}")
-        else:
-            ssl_creds = grpc.ssl_channel_credentials()
-            call_creds = grpc.access_token_call_credentials(token)
-            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
-            self._channel = grpc.secure_channel(
-                target=f"{host}",
-                credentials=creds,
-            )
-        self._stub = connector_service.ConnectorPublicServiceStub(self._channel)
+        for instance in global_config.hosts.keys():
+            if global_config.hosts[instance].token is None:
+                channel = grpc.insecure_channel(global_config.hosts[instance].url)
+            else:
+                ssl_creds = grpc.ssl_channel_credentials()
+                call_creds = grpc.access_token_call_credentials(
+                    global_config.hosts[instance].token
+                )
+                creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+                channel = grpc.secure_channel(
+                    target=global_config.hosts[instance].url,
+                    credentials=creds,
+                )
+            self.hosts[instance]["channel"] = channel
+            self.hosts[instance][
+                "client"
+            ] = connector_service.ConnectorPublicServiceStub(channel)
 
     @property
-    def token(self):
-        return self._token
+    def hosts(self):
+        return self._hosts
 
-    @token.setter
-    def token(self, token: str):
-        self._token = token
-
-    @property
-    def host(self):
-        return self._host
-
-    @host.setter
-    def host(self, host: str):
-        self._host = host
+    @hosts.setter
+    def hosts(self, hosts: str):
+        self._hosts = hosts
 
     @property
-    def port(self):
-        return self._port
+    def instance(self):
+        return self._instance
 
-    @port.setter
-    def port(self, port: str):
-        self._port = port
+    @instance.setter
+    def instance(self, instance: str):
+        self._instance = instance
 
     @grpc_handler
     def liveness(self) -> connector_interface.LivenessResponse:
-        return self._stub.Liveness(request=connector_interface.LivenessRequest())
+        return self.hosts[self.instance]["client"].Liveness(
+            request=connector_interface.LivenessRequest()
+        )
 
     @grpc_handler
     def readiness(self) -> connector_interface.ReadinessResponse:
-        return self._stub.Readiness(request=connector_interface.ReadinessRequest())
+        return self.hosts[self.instance]["client"].Readiness(
+            request=connector_interface.ReadinessRequest()
+        )
 
     @grpc_handler
     def is_serving(self) -> bool:
@@ -94,9 +88,9 @@ class ConnectorClient(Client):
         connector.id = name
         connector.connector_definition_name = definition
         connector.configuration.update(configuration)
-        resp = self._stub.CreateUserConnectorResource(
+        resp = self.hosts[self.instance]["client"].CreateUserConnectorResource(
             request=connector_interface.CreateUserConnectorResourceRequest(
-                connector_resource=connector, parent=self._user.name
+                connector_resource=connector, parent=self.namespace
             )
         )
 
@@ -104,74 +98,96 @@ class ConnectorClient(Client):
 
     @grpc_handler
     def get_connector(self, name: str) -> connector_interface.ConnectorResource:
-        return self._stub.GetUserConnectorResource(
-            request=connector_interface.GetUserConnectorResourceRequest(
-                name=f"{self._user.name}/connector-resources/{name}"
+        return (
+            self.hosts[self.instance]["client"]
+            .GetUserConnectorResource(
+                request=connector_interface.GetUserConnectorResourceRequest(
+                    name=f"{self.namespace}/connector-resources/{name}"
+                )
             )
-        ).connector_resource
+            .connector_resource
+        )
 
     @grpc_handler
     def connect_connector(self, name: str) -> connector_interface.ConnectorResource:
-        return self._stub.ConnectUserConnectorResource(
-            request=connector_interface.ConnectUserConnectorResourceRequest(
-                name=f"{self._user.name}/connector-resources/{name}"
+        return (
+            self.hosts[self.instance]["client"]
+            .ConnectUserConnectorResource(
+                request=connector_interface.ConnectUserConnectorResourceRequest(
+                    name=f"{self.namespace}/connector-resources/{name}"
+                )
             )
-        ).connector_resource
+            .connector_resource
+        )
 
     @grpc_handler
     def disconnect_connector(self, name: str) -> connector_interface.ConnectorResource:
-        return self._stub.DisconnectUserConnectorResource(
-            request=connector_interface.DisconnectUserConnectorResourceRequest(
-                name=f"{self._user.name}/connector-resources/{name}"
+        return (
+            self.hosts[self.instance]["client"]
+            .DisconnectUserConnectorResource(
+                request=connector_interface.DisconnectUserConnectorResourceRequest(
+                    name=f"{self.namespace}/connector-resources/{name}"
+                )
             )
-        ).connector_resource
+            .connector_resource
+        )
 
     @grpc_handler
     def test_connector(self, name: str) -> connector_interface.ConnectorResource.State:
-        return self._stub.TestUserConnectorResource(
-            request=connector_interface.TestUserConnectorResourceRequest(
-                name=f"{self._user.name}/connector-resources/{name}"
+        return (
+            self.hosts[self.instance]["client"]
+            .TestUserConnectorResource(
+                request=connector_interface.TestUserConnectorResourceRequest(
+                    name=f"{self.namespace}/connector-resources/{name}"
+                )
             )
-        ).state
+            .state
+        )
 
     @grpc_handler
     def execute_connector(self, name: str, inputs: list) -> list:
-        return self._stub.ExecuteUserConnectorResource(
-            request=connector_interface.ExecuteUserConnectorResourceRequest(
-                name=f"{self._user.name}/connector-resources/{name}", inputs=inputs
+        return (
+            self.hosts[self.instance]["client"]
+            .ExecuteUserConnectorResource(
+                request=connector_interface.ExecuteUserConnectorResourceRequest(
+                    name=f"{self.namespace}/connector-resources/{name}", inputs=inputs
+                )
             )
-        ).outputs
+            .outputs
+        )
 
     @grpc_handler
     def watch_connector(self, name: str) -> connector_interface.ConnectorResource.State:
-        return self._stub.WatchUserConnectorResource(
-            request=connector_interface.WatchUserConnectorResourceRequest(
-                name=f"{self._user.name}/connector-resources/{name}"
+        return (
+            self.hosts[self.instance]["client"]
+            .WatchUserConnectorResource(
+                request=connector_interface.WatchUserConnectorResourceRequest(
+                    name=f"{self.namespace}/connector-resources/{name}"
+                )
             )
-        ).state
+            .state
+        )
 
     @grpc_handler
     def delete_connector(self, name: str):
         self.disconnect_connector(name)
-        self._stub.DeleteUserConnectorResource(
+        self.hosts[self.instance]["client"].DeleteUserConnectorResource(
             request=connector_interface.DeleteUserConnectorResourceRequest(
-                name=f"{self._user.name}/connector-resources/{name}"
+                name=f"{self.namespace}/connector-resources/{name}"
             )
         )
 
     @grpc_handler
     def list_connectors(self) -> list:
         connectors = []
-        resp = self._stub.ListUserConnectorResources(
-            connector_interface.ListUserConnectorResourcesRequest(
-                parent=self._user.name
-            )
+        resp = self.hosts[self.instance]["client"].ListUserConnectorResources(
+            connector_interface.ListUserConnectorResourcesRequest(parent=self.namespace)
         )
         connectors.extend(resp.connector_resources)
         while resp.next_page_token != "":
-            resp = self._stub.ListUserConnectorResources(
+            resp = self.hosts[self.instance]["client"].ListUserConnectorResources(
                 connector_interface.ListUserConnectorResourcesRequest(
-                    parent=self._user.name,
+                    parent=self.namespace,
                     page_token=resp.next_page_token,
                 )
             )

--- a/instill_sdk/clients/mgmt.py
+++ b/instill_sdk/clients/mgmt.py
@@ -1,18 +1,20 @@
 # pylint: disable=no-member,wrong-import-position
+from collections import defaultdict
 import grpc
 
 import instill_sdk.protogen.base.mgmt.v1alpha.metric_pb2 as metric_interface
 import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
-from instill_sdk.clients.client import API_TOKEN, Client
+from instill_sdk.clients.client import Client
+from instill_sdk.configuration import global_config
 from instill_sdk.utils.error_handler import grpc_handler
 
 # from instill_sdk.utils.logger import Logger
 
 
 class MgmtClient(Client):
-    def __init__(self, token=API_TOKEN, host="localhost", port="7080") -> None:
+    def __init__(self) -> None:
         """Initialize client for management service with target host.
 
         Args:
@@ -21,53 +23,50 @@ class MgmtClient(Client):
             port (str): host port
         """
 
-        self.token = token
-        self.host = host
-        self.port = port
+        self.hosts = defaultdict(dict)
+        self.instance = "default"
 
-        if len(token) == 0:
-            self._channel = grpc.insecure_channel(f"{host}:{port}")
-        else:
-            ssl_creds = grpc.ssl_channel_credentials()
-            call_creds = grpc.access_token_call_credentials(token)
-            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
-            self._channel = grpc.secure_channel(
-                target=f"{host}",
-                credentials=creds,
-            )
-        self._stub = mgmt_service.MgmtPublicServiceStub(self._channel)
-
-    @property
-    def token(self):
-        return self._token
-
-    @token.setter
-    def token(self, token: str):
-        self._token = token
+        for instance in global_config.hosts.keys():
+            if global_config.hosts[instance].token is None:
+                channel = grpc.insecure_channel(global_config.hosts[instance].url)
+            else:
+                ssl_creds = grpc.ssl_channel_credentials()
+                call_creds = grpc.access_token_call_credentials(
+                    global_config.hosts[instance].token
+                )
+                creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+                channel = grpc.secure_channel(
+                    target=global_config.hosts[instance].url,
+                    credentials=creds,
+                )
+            self.hosts[instance]["channel"] = channel
+            self.hosts[instance]["client"] = mgmt_service.MgmtPublicServiceStub(channel)
 
     @property
-    def host(self):
-        return self._host
+    def hosts(self):
+        return self._hosts
 
-    @host.setter
-    def host(self, host: str):
-        self._host = host
+    @hosts.setter
+    def hosts(self, hosts: str):
+        self._hosts = hosts
 
     @property
-    def port(self):
-        return self._port
+    def instance(self):
+        return self._instance
 
-    @port.setter
-    def port(self, port: str):
-        self._port = port
+    @instance.setter
+    def instance(self, instance: str):
+        self._instance = instance
 
     @grpc_handler
     def liveness(self) -> mgmt_interface.LivenessResponse:
-        return self._stub.Liveness(request=mgmt_interface.LivenessRequest())
+        return self.hosts[self.instance]["client"].Liveness(
+            request=mgmt_interface.LivenessRequest()
+        )
 
     @grpc_handler
     def readiness(self) -> mgmt_interface.ReadinessResponse:
-        return self._stub.Readiness(request=mgmt_interface.ReadinessRequest())
+        return self.hosts[self.instance]["client"].Readiness(request=mgmt_interface.ReadinessRequest())
 
     @grpc_handler
     def is_serving(self) -> bool:
@@ -81,7 +80,7 @@ class MgmtClient(Client):
 
     @grpc_handler
     def get_user(self) -> mgmt_interface.User:
-        response = self._stub.QueryAuthenticatedUser(
+        response = self.hosts[self.instance]["client"].QueryAuthenticatedUser(
             request=mgmt_interface.QueryAuthenticatedUserRequest()
         )
         return response.user
@@ -90,7 +89,7 @@ class MgmtClient(Client):
     def list_pipeline_trigger_records(
         self,
     ) -> metric_interface.ListPipelineTriggerRecordsResponse:
-        return self._stub.ListPipelineTriggerRecords(
+        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
             request=metric_interface.ListPipelineTriggerChartRecordsRequest()
         )
 
@@ -98,7 +97,7 @@ class MgmtClient(Client):
     def list_pipeline_trigger_table_records(
         self,
     ) -> metric_interface.ListPipelineTriggerTableRecordsRequest:
-        return self._stub.ListPipelineTriggerRecords(
+        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
             request=metric_interface.ListPipelineTriggerTableRecordsResponse()
         )
 
@@ -106,7 +105,7 @@ class MgmtClient(Client):
     def list_pipeline_trigger_chart_records(
         self,
     ) -> metric_interface.ListPipelineTriggerChartRecordsResponse:
-        return self._stub.ListPipelineTriggerRecords(
+        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
             request=metric_interface.ListPipelineTriggerChartRecordsRequest()
         )
 
@@ -114,7 +113,7 @@ class MgmtClient(Client):
     def list_connector_execute_records(
         self,
     ) -> metric_interface.ListConnectorExecuteRecordsResponse:
-        return self._stub.ListPipelineTriggerRecords(
+        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
             request=metric_interface.ListConnectorExecuteRecordsRequest()
         )
 
@@ -122,7 +121,7 @@ class MgmtClient(Client):
     def list_connector_execute_table_records(
         self,
     ) -> metric_interface.ListConnectorExecuteTableRecordsResponse:
-        return self._stub.ListPipelineTriggerRecords(
+        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
             request=metric_interface.ListConnectorExecuteTableRecordsRequest()
         )
 
@@ -130,6 +129,6 @@ class MgmtClient(Client):
     def list_connector_execute_chart_records(
         self,
     ) -> metric_interface.ListConnectorExecuteChartRecordsResponse:
-        return self._stub.ListPipelineTriggerRecords(
+        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
             request=metric_interface.ListConnectorExecuteChartRecordsRequest()
         )

--- a/instill_sdk/clients/model.py
+++ b/instill_sdk/clients/model.py
@@ -1,81 +1,70 @@
 # pylint: disable=no-member,wrong-import-position
 import time
-
+from collections import defaultdict
 import grpc
 
-# mgmt
-import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
-
 # common
+from instill_sdk.configuration import global_config
+from instill_sdk.utils.error_handler import grpc_handler
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 
 # model
 import instill_sdk.protogen.model.model.v1alpha.model_pb2 as model_interface
 import instill_sdk.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
-from instill_sdk.clients.client import API_TOKEN, Client
-from instill_sdk.utils.error_handler import grpc_handler
+from instill_sdk.clients.client import Client
 
 
 class ModelClient(Client):
-    def __init__(
-        self, user: mgmt_interface.User, token=API_TOKEN, host="localhost", port="9080"
-    ) -> None:
-        """Initialize client for model service with target host.
+    def __init__(self, namespace: str) -> None:
+        self.hosts = defaultdict(dict)
+        self.instance = "default"
+        self.namespace = namespace
 
-        Args:
-            token (str): api token for authentication
-            host (str): host url
-            port (str): host port
-        """
-
-        self.token = token
-        self.host = host
-        self.port = port
-
-        self._user = user
-        if len(token) == 0:
-            self._channel = grpc.insecure_channel(f"{host}:{port}")
-        else:
-            ssl_creds = grpc.ssl_channel_credentials()
-            call_creds = grpc.access_token_call_credentials(token)
-            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
-            self._channel = grpc.secure_channel(
-                target=f"{host}",
-                credentials=creds,
+        for instance in global_config.hosts.keys():
+            if global_config.hosts[instance].token is None:
+                channel = grpc.insecure_channel(global_config.hosts[instance].url)
+            else:
+                ssl_creds = grpc.ssl_channel_credentials()
+                call_creds = grpc.access_token_call_credentials(
+                    global_config.hosts[instance].token
+                )
+                creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+                channel = grpc.secure_channel(
+                    target=global_config.hosts[instance].url,
+                    credentials=creds,
+                )
+            self.hosts[instance]["channel"] = channel
+            self.hosts[instance]["client"] = model_service.ModelPublicServiceStub(
+                channel
             )
-        self._stub = model_service.ModelPublicServiceStub(self._channel)
 
     @property
-    def token(self):
-        return self._token
+    def hosts(self):
+        return self._hosts
 
-    @token.setter
-    def token(self, token: str):
-        self._token = token
-
-    @property
-    def host(self):
-        return self._host
-
-    @host.setter
-    def host(self, host: str):
-        self._host = host
+    @hosts.setter
+    def hosts(self, hosts: str):
+        self._hosts = hosts
 
     @property
-    def port(self):
-        return self._port
+    def instance(self):
+        return self._instance
 
-    @port.setter
-    def port(self, port: str):
-        self._port = port
+    @instance.setter
+    def instance(self, instance: str):
+        self._instance = instance
 
     @grpc_handler
     def liveness(self) -> model_interface.LivenessResponse:
-        return self._stub.Liveness(request=model_interface.LivenessRequest())
+        return self.hosts[self.instance]["client"].Liveness(
+            request=model_interface.LivenessRequest()
+        )
 
     @grpc_handler
     def readiness(self) -> model_interface.ReadinessResponse:
-        return self._stub.Readiness(request=model_interface.ReadinessRequest())
+        return self.hosts[self.instance]["client"].Readiness(
+            request=model_interface.ReadinessRequest()
+        )
 
     @grpc_handler
     def is_serving(self) -> bool:
@@ -89,11 +78,15 @@ class ModelClient(Client):
 
     @grpc_handler
     def watch_model(self, model_name: str) -> model_interface.Model.State:
-        return self._stub.WatchUserModel(
-            request=model_interface.WatchUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}"
+        return (
+            self.hosts[self.instance]["client"]
+            .WatchUserModel(
+                request=model_interface.WatchUserModelRequest(
+                    name=f"{self.namespace}/models/{model_name}"
+                )
             )
-        ).state
+            .state
+        )
 
     @grpc_handler
     def create_model_local(
@@ -110,37 +103,45 @@ class ModelClient(Client):
         with open(model_path, "rb") as f:
             data = f.read()
             req = model_interface.CreateUserModelBinaryFileUploadRequest(
-                parent=self._user.name, model=model, content=data
+                parent=self.namespace, model=model, content=data
             )
-        resp = self._stub.CreateUserModelBinaryFileUpload(request_iterator=iter([req]))
+        resp = self.hosts[self.instance]["client"].CreateUserModelBinaryFileUpload(
+            request_iterator=iter([req])
+        )
 
         while (
-            self._stub.GetModelOperation(
+            self.hosts[self.instance]["client"]
+            .GetModelOperation(
                 request=model_interface.GetModelOperationRequest(
                     name=resp.operation.name
                 )
-            ).operation.done
+            )
+            .operation.done
             is not True
         ):
             time.sleep(1)
 
-        watch_resp = self._stub.WatchUserModel(
+        watch_resp = self.hosts[self.instance]["client"].WatchUserModel(
             request=model_interface.WatchUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}"
+                name=f"{self.namespace}/models/{model_name}"
             )
         )
         while watch_resp.state == 0:
             time.sleep(1)
-            watch_resp = self._stub.WatchUserModel(
+            watch_resp = self.hosts[self.instance]["client"].WatchUserModel(
                 request=model_interface.WatchUserModelRequest(
-                    name=f"{self._user.name}/models/{model_name}"
+                    name=f"{self.namespace}/models/{model_name}"
                 )
             )
 
         if watch_resp.state == 1:
-            return self._stub.GetUserModel(
-                request=model_interface.GetUserModelRequest(name=model_name)
-            ).model
+            return (
+                self.hosts[self.instance]["client"]
+                .GetUserModel(
+                    request=model_interface.GetUserModelRequest(name=model_name)
+                )
+                .model
+            )
 
         raise SystemError("model creation failed")
 
@@ -155,62 +156,72 @@ class ModelClient(Client):
         model.id = name
         model.model_definition = definition
         model.configuration.update(configuration)
-        resp = self._stub.CreateUserModel(
+        resp = self.hosts[self.instance]["client"].CreateUserModel(
             request=model_interface.CreateUserModelRequest(
-                model=model, parent=self._user.name
+                model=model, parent=self.namespace
             )
         )
 
         while (
-            self._stub.GetModelOperation(
+            self.hosts[self.instance]["client"]
+            .GetModelOperation(
                 request=model_interface.GetModelOperationRequest(
                     name=resp.operation.name
                 )
-            ).operation.done
+            )
+            .operation.done
             is not True
         ):
             time.sleep(1)
 
-        watch_resp = self._stub.WatchUserModel(
+        # TODO: due to state update delay of controller
+        # TODO: should optimize this in model-backend
+        time.sleep(3)
+
+        watch_resp = self.hosts[self.instance]["client"].WatchUserModel(
             request=model_interface.WatchUserModelRequest(
-                name=f"{self._user.name}/models/{model.id}"
+                name=f"{self.namespace}/models/{model.id}"
             )
         )
         while watch_resp.state == 0:
             time.sleep(1)
-            watch_resp = self._stub.WatchUserModel(
+            watch_resp = self.hosts[self.instance]["client"].WatchUserModel(
                 request=model_interface.WatchUserModelRequest(
-                    name=f"{self._user.name}/models/{model.id}"
+                    name=f"{self.namespace}/models/{model.id}"
                 )
             )
 
         if watch_resp.state == 1:
-            return self._stub.GetUserModel(
-                request=model_interface.GetUserModelRequest(
-                    name=f"{self._user.name}/models/{model.id}"
+            return (
+                self.hosts[self.instance]["client"]
+                .GetUserModel(
+                    request=model_interface.GetUserModelRequest(
+                        name=f"{self.namespace}/models/{model.id}"
+                    )
                 )
-            ).model
+                .model
+            )
 
         raise SystemError("model creation failed")
 
     @grpc_handler
     def deploy_model(self, model_name: str) -> model_interface.Model.State:
-        self._stub.DeployUserModel(
+        self.hosts[self.instance]["client"].DeployUserModel(
             request=model_interface.DeployUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}"
+                name=f"{self.namespace}/models/{model_name}"
             )
         )
 
-        watch_resp = self._stub.WatchUserModel(
+        watch_resp = self.hosts[self.instance]["client"].WatchUserModel(
             request=model_interface.WatchUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}"
+                name=f"{self.namespace}/models/{model_name}"
             )
         )
         while watch_resp.state not in (2, 3):
             time.sleep(1)
-            watch_resp = self._stub.WatchUserModel(
+            watch_resp = self.hosts[self.instance]["client"].WatchUserModel(
                 request=model_interface.WatchUserModelRequest(
-                    name=f"{self._user.name}/models/{model_name}"
+                    name=f"{self.namespace}/models/{model_name}"
                 )
             )
 
@@ -218,22 +229,22 @@ class ModelClient(Client):
 
     @grpc_handler
     def undeploy_model(self, model_name: str) -> model_interface.Model.State:
-        self._stub.UndeployUserModel(
+        self.hosts[self.instance]["client"].UndeployUserModel(
             request=model_interface.UndeployUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}"
+                name=f"{self.namespace}/models/{model_name}"
             )
         )
 
-        watch_resp = self._stub.WatchUserModel(
+        watch_resp = self.hosts[self.instance]["client"].WatchUserModel(
             request=model_interface.WatchUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}"
+                name=f"{self.namespace}/models/{model_name}"
             )
         )
         while watch_resp.state not in (1, 3):
             time.sleep(1)
-            watch_resp = self._stub.WatchUserModel(
+            watch_resp = self.hosts[self.instance]["client"].WatchUserModel(
                 request=model_interface.WatchUserModelRequest(
-                    name=f"{self._user.name}/models/{model_name}"
+                    name=f"{self.namespace}/models/{model_name}"
                 )
             )
 
@@ -241,42 +252,83 @@ class ModelClient(Client):
 
     @grpc_handler
     def trigger_model(self, model_name: str, task_inputs: list) -> list:
-        resp = self._stub.TriggerUserModel(
+        resp = self.hosts[self.instance]["client"].TriggerUserModel(
             request=model_interface.TriggerUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}", task_inputs=task_inputs
+                name=f"{self.namespace}/models/{model_name}", task_inputs=task_inputs
             )
         )
         return resp.task_outputs
 
     @grpc_handler
     def delete_model(self, model_name: str):
-        self._stub.DeleteUserModel(
+        self.hosts[self.instance]["client"].DeleteUserModel(
             request=model_interface.DeleteUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}"
+                name=f"{self.namespace}/models/{model_name}"
             )
         )
 
     @grpc_handler
     def get_model(self, model_name: str) -> model_interface.Model:
-        return self._stub.GetUserModel(
-            request=model_interface.GetUserModelRequest(
-                name=f"{self._user.name}/models/{model_name}"
-            )
-        ).model
-
-    @grpc_handler
-    def list_models(self) -> list:
-        models = []
-        resp = self._stub.ListUserModels(
-            request=model_interface.ListUserModelsRequest(parent=self._user.name)
-        )
-        models.extend(resp.models)
-        while resp.next_page_token != "":
-            resp = self._stub.ListUserModels(
-                request=model_interface.ListUserModelsRequest(
-                    parent=self._user.name,
-                    page_token=resp.next_page_token,
+        return (
+            self.hosts[self.instance]["client"]
+            .GetUserModel(
+                request=model_interface.GetUserModelRequest(
+                    name=f"{self.namespace}/models/{model_name}"
                 )
             )
+            .model
+        )
+
+    @grpc_handler
+    def get_model_by_uid(self, model_uid: str) -> model_interface.Model:
+        return (
+            self.hosts[self.instance]["client"]
+            .GetUserModel(
+                request=model_interface.LookUpModelRequest(
+                    permalink=f"models/{model_uid}"
+                )
+            )
+            .model
+        )
+
+    @grpc_handler
+    def get_model_card(self, model_name: str) -> model_interface.Model:
+        return (
+            self.hosts[self.instance]["client"]
+            .GetUserModel(
+                request=model_interface.GetUserModelCardRequest(
+                    name=f"{self.namespace}/models/{model_name}"
+                )
+            )
+            .readme
+        )
+
+    @grpc_handler
+    def list_models(self, public=False) -> list:
+        models = []
+        if not public:
+            resp = self.hosts[self.instance]["client"].ListUserModels(
+                request=model_interface.ListUserModelsRequest(parent=self.namespace)
+            )
             models.extend(resp.models)
+            while resp.next_page_token != "":
+                resp = self.hosts[self.instance]["client"].ListUserModels(
+                    request=model_interface.ListUserModelsRequest(
+                        parent=self.namespace,
+                        page_token=resp.next_page_token,
+                    )
+                )
+                models.extend(resp.models)
+        else:
+            resp = self.hosts[self.instance]["client"].ListModels(
+                request=model_interface.ListModelsRequest()
+            )
+            models.extend(resp.models)
+            while resp.next_page_token != "":
+                resp = self.hosts[self.instance]["client"].ListUserModels(
+                    request=model_interface.ListModelsRequest(
+                        page_token=resp.next_page_token,
+                    )
+                )
+                models.extend(resp.models)
         return models

--- a/instill_sdk/clients/pipeline.py
+++ b/instill_sdk/clients/pipeline.py
@@ -1,83 +1,73 @@
 # pylint: disable=no-member,wrong-import-position
 from typing import Tuple
-
+from collections import defaultdict
 import grpc
 
-# mgmt
-import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
+# common
+from instill_sdk.clients.client import Client
+from instill_sdk.utils.error_handler import grpc_handler
+from instill_sdk.configuration import global_config
+import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 
 # from instill_sdk.utils.logger import Logger
-import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
+
 
 # pipeline
 import instill_sdk.protogen.vdp.pipeline.v1alpha.pipeline_pb2 as pipeline_interface
 import instill_sdk.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
 
-# common
-from instill_sdk.clients.client import API_TOKEN, Client
-from instill_sdk.utils.error_handler import grpc_handler
-
 
 class PipelineClient(Client):
-    def __init__(
-        self, user: mgmt_interface.User, token=API_TOKEN, host="localhost", port="8080"
-    ) -> None:
-        """Initialize client for pipeline service with target host.
+    def __init__(self, namespace: str) -> None:
+        self.hosts = defaultdict(dict)
+        self.instance = "default"
+        self.namespace = namespace
 
-        Args:
-            token (str): api token for authentication
-            host (str): host url
-            port (str): host port
-        """
-
-        self.token = token
-        self.host = host
-        self.port = port
-
-        self._user = user
-        if len(token) == 0:
-            self._channel = grpc.insecure_channel(f"{host}:{port}")
-        else:
-            ssl_creds = grpc.ssl_channel_credentials()
-            call_creds = grpc.access_token_call_credentials(token)
-            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
-            self._channel = grpc.secure_channel(
-                target=f"{host}",
-                credentials=creds,
+        for instance in global_config.hosts.keys():
+            if global_config.hosts[instance].token is None:
+                channel = grpc.insecure_channel(global_config.hosts[instance].url)
+            else:
+                ssl_creds = grpc.ssl_channel_credentials()
+                call_creds = grpc.access_token_call_credentials(
+                    global_config.hosts[instance].token
+                )
+                creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+                channel = grpc.secure_channel(
+                    target=global_config.hosts[instance].url,
+                    credentials=creds,
+                )
+            self.hosts[instance]["channel"] = channel
+            self.hosts[instance]["client"] = pipeline_service.PipelinePublicServiceStub(
+                channel
             )
-        self._stub = pipeline_service.PipelinePublicServiceStub(self._channel)
 
     @property
-    def token(self):
-        return self._token
+    def hosts(self):
+        return self._hosts
 
-    @token.setter
-    def token(self, token: str):
-        self._token = token
-
-    @property
-    def host(self):
-        return self._host
-
-    @host.setter
-    def host(self, host: str):
-        self._host = host
+    @hosts.setter
+    def hosts(self, hosts: str):
+        self._hosts = hosts
 
     @property
-    def port(self):
-        return self._port
+    def instance(self):
+        return self._instance
 
-    @port.setter
-    def port(self, port: str):
-        self._port = port
+    @instance.setter
+    def instance(self, instance: str):
+        self._instance = instance
 
     @grpc_handler
     def liveness(self) -> pipeline_interface.LivenessResponse:
-        return self._stub.Liveness(request=pipeline_interface.LivenessRequest())
+        return self.hosts[self.instance]["client"].Liveness(
+            request=pipeline_interface.LivenessRequest()
+        )
 
     @grpc_handler
     def readiness(self) -> pipeline_interface.ReadinessResponse:
-        return self._stub.Readiness(request=pipeline_interface.ReadinessRequest())
+        return self.hosts[self.instance]["client"].Readiness(
+            request=pipeline_interface.ReadinessRequest()
+        )
 
     @grpc_handler
     def is_serving(self) -> bool:
@@ -99,59 +89,67 @@ class PipelineClient(Client):
             id=name,
             recipe=recipe,
         )
-        resp = self._stub.CreateUserPipeline(
+        resp = self.hosts[self.instance]["client"].CreateUserPipeline(
             request=pipeline_interface.CreateUserPipelineRequest(
-                pipeline=pipeline, parent=self._user.name
+                pipeline=pipeline, parent=self.namespace
             )
         )
         return resp.pipeline
 
     @grpc_handler
     def get_pipeline(self, name: str) -> pipeline_interface.Pipeline:
-        return self._stub.GetUserPipeline(
-            request=pipeline_interface.GetUserPipelineRequest(
-                name=f"{self._user.name}/pipelines/{name}"
+        return (
+            self.hosts[self.instance]["client"]
+            .GetUserPipeline(
+                request=pipeline_interface.GetUserPipelineRequest(
+                    name=f"{self.namespace}/pipelines/{name}"
+                )
             )
-        ).pipeline
+            .pipeline
+        )
 
     @grpc_handler
     def validate_pipeline(self, name: str) -> pipeline_interface.Pipeline:
-        return self._stub.ValidateUserPipeline(
-            request=pipeline_interface.ValidateUserPipelineRequest(
-                name=f"{self._user.name}/pipelines/{name}"
+        return (
+            self.hosts[self.instance]["client"]
+            .ValidateUserPipeline(
+                request=pipeline_interface.ValidateUserPipelineRequest(
+                    name=f"{self.namespace}/pipelines/{name}"
+                )
             )
-        ).pipeline
+            .pipeline
+        )
 
     @grpc_handler
     def trigger_pipeline(
         self, name: str, inputs: list
     ) -> Tuple[list, pipeline_interface.TriggerMetadata]:
-        resp = self._stub.TriggerUserPipeline(
+        resp = self.hosts[self.instance]["client"].TriggerUserPipeline(
             request=pipeline_interface.TriggerUserPipelineRequest(
-                name=f"{self._user.name}/pipelines/{name}", inputs=inputs
+                name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             )
         )
         return resp.outputs, resp.metadata
 
     @grpc_handler
     def delete_pipeline(self, name: str):
-        self._stub.DeleteUserPipeline(
+        self.hosts[self.instance]["client"].DeleteUserPipeline(
             request=pipeline_interface.DeleteUserPipelineRequest(
-                name=f"{self._user.name}/pipelines/{name}"
+                name=f"{self.namespace}/pipelines/{name}"
             )
         )
 
     @grpc_handler
     def list_pipelines(self) -> list:
         pipelines = []
-        resp = self._stub.ListUserPipelines(
-            pipeline_interface.ListUserPipelinesRequest(parent=self._user.name)
+        resp = self.hosts[self.instance]["client"].ListUserPipelines(
+            pipeline_interface.ListUserPipelinesRequest(parent=self.namespace)
         )
         pipelines.extend(resp.pipelines)
         while resp.next_page_token != "":
-            resp = self._stub.ListUserPipelines(
+            resp = self.hosts[self.instance]["client"].ListUserPipelines(
                 pipeline_interface.ListUserPipelinesRequest(
-                    parent=self._user.name,
+                    parent=self.namespace,
                     page_token=resp.next_page_token,
                 )
             )

--- a/instill_sdk/configuration/__init__.py
+++ b/instill_sdk/configuration/__init__.py
@@ -14,13 +14,12 @@ CONFIG_DIR = Path(
 
 
 class _InstillHost(BaseModel):
-    alias: t.Optional[str] = ""
     url: str
     token: t.Optional[str] = ""
 
 
 class _Config(BaseModel):
-    remotes: t.Optional[t.List[_InstillHost]] = None
+    hosts: t.Optional[t.Dict[str, _InstillHost]] = None
 
 
 class Configuration:
@@ -30,8 +29,8 @@ class Configuration:
         CONFIG_DIR.mkdir(exist_ok=True)
 
     @property
-    def remotes(self) -> t.Optional[t.List[_InstillHost]]:
-        return self._config.remotes
+    def hosts(self) -> t.Optional[t.Dict[str, _InstillHost]]:
+        return self._config.hosts
 
     def load(self) -> None:
         path = CONFIG_DIR / "config.yaml"
@@ -47,5 +46,5 @@ class Configuration:
             raise BaseException(f"Invalid configuration file at '{path}'") from e
 
 
-config = Configuration()
-config.load()
+global_config = Configuration()
+global_config.load()

--- a/instill_sdk/tests/test_client.py
+++ b/instill_sdk/tests/test_client.py
@@ -1,15 +1,14 @@
 """Sample unit test module using pytest-describe and expecter."""
 # pylint: disable=redefined-outer-name,unused-variable,expression-not-assigned,singleton-comparison
-
 from instill_sdk.clients.mgmt import MgmtClient
 
 
-def set_and_get_host_to_client():
+def set_and_get_instance_to_client():
     def when_set(expect):
-        test_client = MgmtClient
-        test_client.host = "123"  # type: ignore
-        expect(test_client.host) == "123"
+        test_client = MgmtClient()
+        test_client.instance = "test"
+        expect(test_client.instance) == "test"
 
     def when_not_set(expect):
-        test_client = MgmtClient
-        expect(test_client.host) == "localhost"
+        test_client = MgmtClient()
+        expect(test_client.instance) == "default"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-outer-name,unused-variable,expression-not-assigned
 
+from collections import defaultdict
 
 from instill_sdk.clients.connector import ConnectorClient
 from instill_sdk.clients.mgmt import MgmtClient
@@ -8,77 +9,54 @@ from instill_sdk.clients.pipeline import PipelineClient
 
 
 def describe_client():
+    def describe_instance():
+        def when_not_set(expect):
+            mgmt_client = MgmtClient()
+            expect(mgmt_client.instance) == "default"
+            model_client = ModelClient(namespace="")
+            expect(model_client.instance) == "default"
+            pipeline_client = PipelineClient(namespace="")
+            expect(pipeline_client.instance) == "default"
+            connector_client = ConnectorClient(namespace="")
+            expect(connector_client.instance) == "default"
+
+        def when_set_correct_type(expect):
+            mgmt_client = MgmtClient()
+            mgmt_client.instance = "staging"
+            expect(mgmt_client.instance) == "staging"
+            model_client = ModelClient(namespace="")
+            model_client.instance = "staging"
+            expect(model_client.instance) == "staging"
+            pipeline_client = PipelineClient(namespace="")
+            pipeline_client.instance = "staging"
+            expect(pipeline_client.instance) == "staging"
+            connector_client = ConnectorClient(namespace="")
+            connector_client.instance = "staging"
+            expect(connector_client.instance) == "staging"
+
     def describe_host():
         def when_not_set(expect):
             mgmt_client = MgmtClient()
-            expect(mgmt_client.host) == "localhost"
-            model_client = ModelClient(user=mgmt_client.get_user())
-            expect(model_client.host) == "localhost"
-            pipeline_client = PipelineClient(user=mgmt_client.get_user())
-            expect(pipeline_client.host) == "localhost"
-            connector_client = ConnectorClient(user=mgmt_client.get_user())
-            expect(connector_client.host) == "localhost"
+            expect(mgmt_client.hosts) is None
+            model_client = ModelClient(namespace="")
+            expect(model_client.hosts) is None
+            pipeline_client = PipelineClient(namespace="")
+            expect(pipeline_client.hosts) is None
+            connector_client = ConnectorClient(namespace="")
+            expect(connector_client.hosts) is None
 
         def when_set_correct_type(expect):
             mgmt_client = MgmtClient()
-            mgmt_client.host = "instill"
-            expect(mgmt_client.host) == "instill"
-            model_client = ModelClient(user=mgmt_client.get_user())
-            model_client.host = "instill"
-            expect(model_client.host) == "instill"
-            pipeline_client = PipelineClient(user=mgmt_client.get_user())
-            pipeline_client.host = "instill"
-            expect(pipeline_client.host) == "instill"
-            connector_client = ConnectorClient(user=mgmt_client.get_user())
-            connector_client.host = "instill"
-            expect(connector_client.host) == "instill"
-
-    def describe_token():
-        def when_not_set(expect):
-            mgmt_client = MgmtClient()
-            expect(mgmt_client.token) == ""
-            model_client = ModelClient(user=mgmt_client.get_user())
-            expect(model_client.token) == ""
-            pipeline_client = PipelineClient(user=mgmt_client.get_user())
-            expect(pipeline_client.token) == ""
-            connector_client = ConnectorClient(user=mgmt_client.get_user())
-            expect(connector_client.token) == ""
-
-        def when_set_correct_type(expect):
-            mgmt_client = MgmtClient()
-            mgmt_client.token = "instill"
-            expect(mgmt_client.token) == "instill"
-            model_client = ModelClient(user=mgmt_client.get_user())
-            model_client.token = "instill"
-            expect(model_client.token) == "instill"
-            pipeline_client = PipelineClient(user=mgmt_client.get_user())
-            pipeline_client.token = "instill"
-            expect(pipeline_client.token) == "instill"
-            connector_client = ConnectorClient(user=mgmt_client.get_user())
-            connector_client.token = "instill"
-            expect(connector_client.token) == "instill"
-
-    def describe_port():
-        def when_not_set(expect):
-            mgmt_client = MgmtClient()
-            expect(mgmt_client.port) == "7080"
-            model_client = ModelClient(user=mgmt_client.get_user())
-            expect(model_client.port) == "9080"
-            pipeline_client = PipelineClient(user=mgmt_client.get_user())
-            expect(pipeline_client.port) == "8080"
-            connector_client = ConnectorClient(user=mgmt_client.get_user())
-            expect(connector_client.port) == "8080"
-
-        def when_set_correct_type(expect):
-            mgmt_client = MgmtClient()
-            mgmt_client.port = "instill"
-            expect(mgmt_client.port) == "instill"
-            model_client = ModelClient(user=mgmt_client.get_user())
-            model_client.port = "instill"
-            expect(model_client.port) == "instill"
-            pipeline_client = PipelineClient(user=mgmt_client.get_user())
-            pipeline_client.port = "instill"
-            expect(pipeline_client.port) == "instill"
-            connector_client = ConnectorClient(user=mgmt_client.get_user())
-            connector_client.port = "instill"
-            expect(connector_client.port) == "instill"
+            d = defaultdict(dict)  # type: ignore
+            d["test_instance"] = dict({"url": "test_url"})
+            mgmt_client.hosts = d
+            expect(mgmt_client.hosts["test_instance"]["url"]) == "test_url"
+            model_client = ModelClient(namespace="")
+            model_client.hosts = d
+            expect(model_client.hosts["test_instance"]["url"]) == "test_url"
+            pipeline_client = PipelineClient(namespace="")
+            pipeline_client.hosts = d
+            expect(pipeline_client.hosts["test_instance"]["url"]) == "test_url"
+            connector_client = ConnectorClient(namespace="")
+            connector_client.hosts = d
+            expect(connector_client.hosts["test_instance"]["url"]) == "test_url"


### PR DESCRIPTION
Because

- allow user to interact with multiple instances with just one client

This commit

- support multi instances in client
- add missing functions supported in API
