### PR TITLE
refactor(clients,resources): adopt multi instance and update resource interaface

### DIFF
--- a/instill_sdk/__main__.py
+++ b/instill_sdk/__main__.py
@@ -5,8 +5,6 @@ import pprint
 
 from instill_sdk.configuration import global_config
 
-# from instill_sdk.client import
-
 if __name__ == "__main__":  # pragma: no cover
     # main()  # pylint: disable=no-value-for-parameter
     print("======================Configured Hosts======================")

--- a/instill_sdk/clients/__init__.py
+++ b/instill_sdk/clients/__init__.py
@@ -1,0 +1,5 @@
+from instill_sdk.clients.client import InstillClient
+from instill_sdk.clients.connector import ConnectorClient
+from instill_sdk.clients.mgmt import MgmtClient
+from instill_sdk.clients.model import ModelClient
+from instill_sdk.clients.pipeline import PipelineClient

--- a/instill_sdk/clients/base.py
+++ b/instill_sdk/clients/base.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+
+
+class Client(ABC):
+    """Base interface class for creating mgmt/pipeline/connector/model clients.
+
+    Args:
+        ABC (abc.ABCMeta): std abstract class
+    """
+
+    @property
+    @abstractmethod
+    def hosts(self):
+        pass
+
+    @hosts.setter
+    @abstractmethod
+    def hosts(self):
+        pass
+
+    @property
+    @abstractmethod
+    def instance(self):
+        pass
+
+    @instance.setter
+    @abstractmethod
+    def instance(self):
+        pass
+
+    @abstractmethod
+    def liveness(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def readiness(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_serving(self):
+        raise NotImplementedError

--- a/instill_sdk/clients/client.py
+++ b/instill_sdk/clients/client.py
@@ -1,42 +1,72 @@
-# pylint: disable=no-member,wrong-import-position
-from abc import ABC, abstractmethod
+# pylint: disable=no-name-in-module
+from instill_sdk.clients.connector import ConnectorClient
+from instill_sdk.clients.mgmt import MgmtClient
+from instill_sdk.clients.model import ModelClient
+from instill_sdk.clients.pipeline import PipelineClient
+
+_mgmt_client = None
+_connector_client = None
+_pipeline_client = None
+_model_client = None
+_client = None
 
 
-class Client(ABC):
-    """Base interface class for creating mgmt/pipeline/connector/model clients.
+def _get_mgmt_client() -> MgmtClient:
+    global _mgmt_client
 
-    Args:
-        ABC (abc.ABCMeta): std abstract class
-    """
+    if _mgmt_client is None:
+        _mgmt_client = MgmtClient()
 
-    @property
-    @abstractmethod
-    def hosts(self):
-        pass
+    return _mgmt_client
 
-    @hosts.setter
-    @abstractmethod
-    def hosts(self):
-        pass
 
-    @property
-    @abstractmethod
-    def instance(self):
-        pass
+def _get_connector_clinet() -> ConnectorClient:
+    global _connector_client
 
-    @instance.setter
-    @abstractmethod
-    def instance(self):
-        pass
+    if _connector_client is None:
+        _connector_client = ConnectorClient(
+            namespace=_get_mgmt_client().get_user().name
+        )
 
-    @abstractmethod
-    def liveness(self):
-        raise NotImplementedError
+    return _connector_client
 
-    @abstractmethod
-    def readiness(self):
-        raise NotImplementedError
 
-    @abstractmethod
-    def is_serving(self):
-        raise NotImplementedError
+def _get_pipeline_clinet() -> PipelineClient:
+    global _pipeline_client
+
+    if _pipeline_client is None:
+        _pipeline_client = PipelineClient(namespace=_get_mgmt_client().get_user().name)
+
+    return _pipeline_client
+
+
+def _get_model_clinet() -> ModelClient:
+    global _model_client
+
+    if _model_client is None:
+        _model_client = ModelClient(namespace=_get_mgmt_client().get_user().name)
+
+    return _model_client
+
+
+class InstillClient:
+    def __init__(self) -> None:
+        self.mgmt_service = _get_mgmt_client()
+        self.connector_service = _get_connector_clinet()
+        self.pipeline_service = _get_pipeline_clinet()
+        self.model_serevice = _get_model_clinet()
+
+    def set_instance(self, instance: str):
+        self.mgmt_service.instance = instance
+        self.connector_service.instance = instance
+        self.pipeline_service.instance = instance
+        self.model_serevice.instance = instance
+
+
+def get_client() -> InstillClient:
+    global _client
+
+    if _client is None:
+        _client = InstillClient()
+
+    return _client

--- a/instill_sdk/clients/connector.py
+++ b/instill_sdk/clients/connector.py
@@ -8,7 +8,7 @@ import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as health
 # connector
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_pb2 as connector_interface
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_public_service_pb2_grpc as connector_service
-from instill_sdk.clients.client import Client
+from instill_sdk.clients.base import Client
 
 # common
 from instill_sdk.configuration import global_config
@@ -58,19 +58,16 @@ class ConnectorClient(Client):
     def instance(self, instance: str):
         self._instance = instance
 
-    @grpc_handler
     def liveness(self) -> connector_interface.LivenessResponse:
         return self.hosts[self.instance]["client"].Liveness(
             request=connector_interface.LivenessRequest()
         )
 
-    @grpc_handler
     def readiness(self) -> connector_interface.ReadinessResponse:
         return self.hosts[self.instance]["client"].Readiness(
             request=connector_interface.ReadinessRequest()
         )
 
-    @grpc_handler
     def is_serving(self) -> bool:
         try:
             return (

--- a/instill_sdk/clients/mgmt.py
+++ b/instill_sdk/clients/mgmt.py
@@ -7,7 +7,7 @@ import instill_sdk.protogen.base.mgmt.v1alpha.metric_pb2 as metric_interface
 import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill_sdk.protogen.base.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
 import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
-from instill_sdk.clients.client import Client
+from instill_sdk.clients.base import Client
 from instill_sdk.configuration import global_config
 from instill_sdk.utils.error_handler import grpc_handler
 
@@ -16,14 +16,6 @@ from instill_sdk.utils.error_handler import grpc_handler
 
 class MgmtClient(Client):
     def __init__(self) -> None:
-        """Initialize client for management service with target host.
-
-        Args:
-            token (str): api token for authentication
-            host (str): host url
-            port (str): host port
-        """
-
         self.hosts = defaultdict(dict)
         self.instance = "default"
 
@@ -62,19 +54,16 @@ class MgmtClient(Client):
     def instance(self, instance: str):
         self._instance = instance
 
-    @grpc_handler
     def liveness(self) -> mgmt_interface.LivenessResponse:
         return self.hosts[self.instance]["client"].Liveness(
             request=mgmt_interface.LivenessRequest()
         )
 
-    @grpc_handler
     def readiness(self) -> mgmt_interface.ReadinessResponse:
         return self.hosts[self.instance]["client"].Readiness(
             request=mgmt_interface.ReadinessRequest()
         )
 
-    @grpc_handler
     def is_serving(self) -> bool:
         try:
             return (

--- a/instill_sdk/clients/model.py
+++ b/instill_sdk/clients/model.py
@@ -9,7 +9,7 @@ import instill_sdk.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as health
 # model
 import instill_sdk.protogen.model.model.v1alpha.model_pb2 as model_interface
 import instill_sdk.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
-from instill_sdk.clients.client import Client
+from instill_sdk.clients.base import Client
 
 # common
 from instill_sdk.configuration import global_config
@@ -57,19 +57,16 @@ class ModelClient(Client):
     def instance(self, instance: str):
         self._instance = instance
 
-    @grpc_handler
     def liveness(self) -> model_interface.LivenessResponse:
         return self.hosts[self.instance]["client"].Liveness(
             request=model_interface.LivenessRequest()
         )
 
-    @grpc_handler
     def readiness(self) -> model_interface.ReadinessResponse:
         return self.hosts[self.instance]["client"].Readiness(
             request=model_interface.ReadinessRequest()
         )
 
-    @grpc_handler
     def is_serving(self) -> bool:
         try:
             return (

--- a/instill_sdk/clients/pipeline.py
+++ b/instill_sdk/clients/pipeline.py
@@ -11,7 +11,7 @@ import instill_sdk.protogen.vdp.pipeline.v1alpha.pipeline_pb2 as pipeline_interf
 import instill_sdk.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
 
 # common
-from instill_sdk.clients.client import Client
+from instill_sdk.clients.base import Client
 from instill_sdk.configuration import global_config
 from instill_sdk.utils.error_handler import grpc_handler
 
@@ -59,19 +59,16 @@ class PipelineClient(Client):
     def instance(self, instance: str):
         self._instance = instance
 
-    @grpc_handler
     def liveness(self) -> pipeline_interface.LivenessResponse:
         return self.hosts[self.instance]["client"].Liveness(
             request=pipeline_interface.LivenessRequest()
         )
 
-    @grpc_handler
     def readiness(self) -> pipeline_interface.ReadinessResponse:
         return self.hosts[self.instance]["client"].Readiness(
             request=pipeline_interface.ReadinessRequest()
         )
 
-    @grpc_handler
     def is_serving(self) -> bool:
         try:
             return (

--- a/instill_sdk/resources/__init__.py
+++ b/instill_sdk/resources/__init__.py
@@ -1,0 +1,5 @@
+from instill_sdk.resources.connector import Connector
+from instill_sdk.resources.connector_ai import OpenAIConnector, StabilityAIConnector
+from instill_sdk.resources.connector_blockchain import NumbersConnector
+from instill_sdk.resources.connector_data import PineconeConnector
+from instill_sdk.resources.model import GithubModel, HugginfaceModel, Model

--- a/instill_sdk/resources/connector.py
+++ b/instill_sdk/resources/connector.py
@@ -1,26 +1,26 @@
-# pylint: disable=no-member,wrong-import-position
+# pylint: disable=no-member,wrong-import-position,no-name-in-module
 import instill_sdk.protogen.vdp.connector.v1alpha.connector_pb2 as connector_interface
-from instill_sdk.clients.connector import ConnectorClient
+from instill_sdk.clients import InstillClient
 from instill_sdk.resources.resource import Resource
 
 
 class Connector(Resource):
     def __init__(
         self,
-        client: ConnectorClient,
+        client: InstillClient,
         name: str,
         definition: str,
         configuration: dict,
     ) -> None:
         super().__init__()
         self.client = client
-        connector = client.create_connector(
-            name=name,
-            definition=definition,
-            configuration=configuration,
-        )
+        connector = client.connector_service.get_connector(name=name)
         if connector is None:
-            connector = client.get_connector(name=name)
+            connector = client.connector_service.create_connector(
+                name=name,
+                definition=definition,
+                configuration=configuration,
+            )
             if connector is None:
                 raise BaseException("connector creation failed")
 
@@ -29,21 +29,25 @@ class Connector(Resource):
 
     def __del__(self):
         if self.resource is not None:
-            self.client.delete_connector(self.resource.id)
+            self.client.connector_service.delete_connector(self.resource.id)
 
     def __call__(self, task_inputs: list, mode="execute") -> list:
         if not self._is_connect:
             raise BaseException("test and connect the connector first")
         if mode == "execute":
-            return self.client.execute_connector(self.resource.id, task_inputs)
-        return self.client.test_connector(self.resource.id, task_inputs)
+            return self.client.connector_service.execute_connector(
+                self.resource.id, task_inputs
+            )
+        return self.client.connector_service.test_connector(
+            self.resource.id, task_inputs
+        )
 
     @property
     def client(self):
         return self._client
 
     @client.setter
-    def client(self, client: ConnectorClient):
+    def client(self, client: InstillClient):
         self._client = client
 
     @property
@@ -58,10 +62,10 @@ class Connector(Resource):
         return self.resource.connector_definition
 
     def get_state(self) -> connector_interface.ConnectorResource.State:
-        return self.client.watch_connector(self.resource.id)
+        return self.client.connector_service.watch_connector(self.resource.id)
 
     def test(self) -> connector_interface.ConnectorResource.State:
-        state = self.client.test_connector(self.resource.id)
+        state = self.client.connector_service.test_connector(self.resource.id)
         if state == connector_interface.ConnectorResource.STATE_CONNECTED:
             self._is_connect = True
         else:
@@ -70,7 +74,7 @@ class Connector(Resource):
         return state
 
     def connect(self):
-        connector = self.client.connect_connector(self.resource.id)
+        connector = self.client.connector_service.connect_connector(self.resource.id)
         self._is_connect = (
             connector.state == connector_interface.ConnectorResource.STATE_CONNECTED
         )

--- a/instill_sdk/resources/connector_ai.py
+++ b/instill_sdk/resources/connector_ai.py
@@ -1,12 +1,12 @@
-# pylint: disable=no-member,wrong-import-position
-from instill_sdk.clients.connector import ConnectorClient
+# pylint: disable=no-member,wrong-import-position,no-name-in-module
+from instill_sdk.clients import InstillClient
 from instill_sdk.resources.connector import Connector
 
 
 class InstillModelConnector(Connector):
     def __init__(
         self,
-        client: ConnectorClient,
+        client: InstillClient,
         name: str,
         api_token: str,
         server_url: str,
@@ -24,7 +24,7 @@ class InstillModelConnector(Connector):
 class StabilityAIConnector(Connector):
     def __init__(
         self,
-        client: ConnectorClient,
+        client: InstillClient,
         name: str,
         api_key: str,
         task: str,
@@ -42,7 +42,7 @@ class StabilityAIConnector(Connector):
 class OpenAIConnector(Connector):
     def __init__(
         self,
-        client: ConnectorClient,
+        client: InstillClient,
         name: str,
         api_key: str,
         task: str,

--- a/instill_sdk/resources/connector_blockchain.py
+++ b/instill_sdk/resources/connector_blockchain.py
@@ -1,12 +1,12 @@
-# pylint: disable=no-member,wrong-import-position
-from instill_sdk.clients.connector import ConnectorClient
+# pylint: disable=no-member,wrong-import-position,no-name-in-module
+from instill_sdk.clients import InstillClient
 from instill_sdk.resources.connector import Connector
 
 
 class NumbersConnector(Connector):
     def __init__(
         self,
-        client: ConnectorClient,
+        client: InstillClient,
         name: str,
         capture_token: str,
         asset_type: str,

--- a/instill_sdk/resources/connector_data.py
+++ b/instill_sdk/resources/connector_data.py
@@ -1,12 +1,12 @@
-# pylint: disable=no-member,wrong-import-position
-from instill_sdk.clients.connector import ConnectorClient
+# pylint: disable=no-member,wrong-import-position,no-name-in-module
+from instill_sdk.clients import InstillClient
 from instill_sdk.resources.connector import Connector
 
 
 class PineconeConnector(Connector):
     def __init__(
         self,
-        client: ConnectorClient,
+        client: InstillClient,
         name: str,
         api_key: str,
         server_url: str,

--- a/instill_sdk/tests/test_client.py
+++ b/instill_sdk/tests/test_client.py
@@ -1,6 +1,6 @@
 """Sample unit test module using pytest-describe and expecter."""
-# pylint: disable=redefined-outer-name,unused-variable,expression-not-assigned,singleton-comparison
-from instill_sdk.clients.mgmt import MgmtClient
+# pylint: disable=no-name-in-module,unused-variable,expression-not-assigned
+from instill_sdk.clients import MgmtClient
 
 
 def set_and_get_instance_to_client():

--- a/instill_sdk/utils/error_handler.py
+++ b/instill_sdk/utils/error_handler.py
@@ -1,4 +1,4 @@
-# pylint: disable=inconsistent-return-statements
+# pylint: disable=inconsistent-return-statements,no-member
 import os
 
 import grpc
@@ -6,12 +6,20 @@ import grpc
 from instill_sdk.utils.logger import Logger
 
 
+class NotServingException(Exception):
+    def __str__(self) -> str:
+        return "target host is not serving"
+
+
 def grpc_handler(func):
     def func_wrapper(*args, **kwargs):
         try:
+            if not args[0].is_serving():
+                raise NotServingException
             return func(*args, **kwargs)
         except grpc.RpcError as rpc_error:
-            Logger.exception(rpc_error)
+            Logger.w(rpc_error.code())
+            Logger.w(rpc_error.details())
         except Exception as e:
             Logger.exception(e)
             os._exit(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,9 @@
 """Integration tests configuration file."""
-# pylint: disable=unused-import
+# pylint: disable=unused-import,no-name-in-module
 
 import pytest
 
-from instill_sdk.clients.connector import ConnectorClient
-from instill_sdk.clients.mgmt import MgmtClient
-from instill_sdk.clients.model import ModelClient
-from instill_sdk.clients.pipeline import PipelineClient
+from instill_sdk.clients import ConnectorClient, MgmtClient, ModelClient, PipelineClient
 from instill_sdk.tests.conftest import pytest_configure
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,8 @@
-# pylint: disable=redefined-outer-name,unused-variable,expression-not-assigned
+# pylint: disable=redefined-outer-name,unused-variable,expression-not-assigned,no-name-in-module
 
 from collections import defaultdict
 
-from instill_sdk.clients.connector import ConnectorClient
-from instill_sdk.clients.mgmt import MgmtClient
-from instill_sdk.clients.model import ModelClient
-from instill_sdk.clients.pipeline import PipelineClient
+from instill_sdk.clients import ConnectorClient, MgmtClient, ModelClient, PipelineClient
 
 
 def describe_client():


### PR DESCRIPTION
Because

- allow better UX when using and implementing `resource`

This commit

- adopt multi instance `client` in `resource`
- update `resource` interface
- update integration-test
