### PR TITLE
refactor(connector): remove connect/disconnect

### DIFF
--- a/instill_sdk/clients/model.py
+++ b/instill_sdk/clients/model.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-member,wrong-import-position
 import time
 from collections import defaultdict
+from typing import Tuple
 
 import grpc
 
@@ -304,31 +305,14 @@ class ModelClient(Client):
         )
 
     @grpc_handler
-    def list_models(self, public=False) -> list:
-        models = []
+    def list_models(self, public=False) -> Tuple[list, str, int]:
         if not public:
             resp = self.hosts[self.instance]["client"].ListUserModels(
                 request=model_interface.ListUserModelsRequest(parent=self.namespace)
             )
-            models.extend(resp.models)
-            while resp.next_page_token != "":
-                resp = self.hosts[self.instance]["client"].ListUserModels(
-                    request=model_interface.ListUserModelsRequest(
-                        parent=self.namespace,
-                        page_token=resp.next_page_token,
-                    )
-                )
-                models.extend(resp.models)
         else:
             resp = self.hosts[self.instance]["client"].ListModels(
                 request=model_interface.ListModelsRequest()
             )
-            models.extend(resp.models)
-            while resp.next_page_token != "":
-                resp = self.hosts[self.instance]["client"].ListUserModels(
-                    request=model_interface.ListModelsRequest(
-                        page_token=resp.next_page_token,
-                    )
-                )
-                models.extend(resp.models)
-        return models
+
+        return resp.models, resp.next_page_token, resp.total_size

--- a/instill_sdk/clients/pipeline.py
+++ b/instill_sdk/clients/pipeline.py
@@ -139,19 +139,14 @@ class PipelineClient(Client):
         )
 
     @grpc_handler
-    def list_pipelines(self) -> list:
-        pipelines = []
-        resp = self.hosts[self.instance]["client"].ListUserPipelines(
-            pipeline_interface.ListUserPipelinesRequest(parent=self.namespace)
-        )
-        pipelines.extend(resp.pipelines)
-        while resp.next_page_token != "":
+    def list_pipelines(self, public=False) -> Tuple[list, str, int]:
+        if not public:
             resp = self.hosts[self.instance]["client"].ListUserPipelines(
-                pipeline_interface.ListUserPipelinesRequest(
-                    parent=self.namespace,
-                    page_token=resp.next_page_token,
-                )
+                pipeline_interface.ListUserPipelinesRequest(parent=self.namespace)
             )
-            pipelines.extend(resp.pipelines)
+        else:
+            resp = self.hosts[self.instance]["client"].ListPipelines(
+                pipeline_interface.ListPipelinesRequest()
+            )
 
-        return pipelines
+        return resp.pipelines, resp.next_page_token, resp.total_size

--- a/instill_sdk/resources/connector.py
+++ b/instill_sdk/resources/connector.py
@@ -25,15 +25,12 @@ class Connector(Resource):
                 raise BaseException("connector creation failed")
 
         self.resource = connector
-        self._is_connect = False
 
     def __del__(self):
         if self.resource is not None:
             self.client.connector_service.delete_connector(self.resource.id)
 
     def __call__(self, task_inputs: list, mode="execute") -> list:
-        if not self._is_connect:
-            raise BaseException("test and connect the connector first")
         if mode == "execute":
             return self.client.connector_service.execute_connector(
                 self.resource.id, task_inputs
@@ -65,16 +62,4 @@ class Connector(Resource):
         return self.client.connector_service.watch_connector(self.resource.id)
 
     def test(self) -> connector_interface.ConnectorResource.State:
-        state = self.client.connector_service.test_connector(self.resource.id)
-        if state == connector_interface.ConnectorResource.STATE_CONNECTED:
-            self._is_connect = True
-        else:
-            self._is_connect = False
-
-        return state
-
-    def connect(self):
-        connector = self.client.connector_service.connect_connector(self.resource.id)
-        self._is_connect = (
-            connector.state == connector_interface.ConnectorResource.STATE_CONNECTED
-        )
+        return self.client.connector_service.test_connector(self.resource.id)


### PR DESCRIPTION
Because

- remove connector's connect/disconnect in connector-backend

This commit

- remove connect/disconnect api
