### PR TITLE
refactor(config): add channel secure option in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ python sdk for Instill AI products
 
 [![Unix Build Status](https://img.shields.io/github/actions/workflow/status/instill-ai/python-sdk/test.yml?branch=main&label=linux)](https://github.com/instill-ai/python-sdk/actions)
 [![Coverage Status](https://img.shields.io/codecov/c/gh/instill-ai/python-sdk)](https://codecov.io/gh/instill-ai/python-sdk)
-[![PyPI License](https://img.shields.io/pypi/l/instill-python-sdk.svg)](https://pypi.org/project/instill-python-sdk)
-[![PyPI Version](https://img.shields.io/pypi/v/instill-python-sdk.svg)](https://pypi.org/project/instill-python-sdk)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/instill-python-sdk.svg?color=orange)](https://pypistats.org/packages/instill-python-sdk)
+[![PyPI License](https://img.shields.io/pypi/l/instill-sdk.svg)](https://pypi.org/project/instill-sdk)
+[![PyPI Version](https://img.shields.io/pypi/v/instill-sdk.svg)](https://pypi.org/project/instill-sdk)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/instill-sdk.svg?color=orange)](https://pypistats.org/packages/instill-sdk)
 
-> :exclamation: **This SDK tool is under heavy development!!**  
-> Currently there is no official wheel on `pypi`, and documentation on how to setup and tutorials will be available soon.Stay tuned!  
-> For now, you can refer to the `Contributing Guidelines` to setup a development environment
+> [!IMPORTANT] **This SDK tool is under heavy development!!**  
+> Currently there has yet to be a stable version release, please feel free to open any issue regarding this SDK here in our [community](https://github.com/instill-ai/community/issues) repo!
 
 ## Setup
 
@@ -21,6 +20,12 @@ python sdk for Instill AI products
 ### Installation
 
 Install it directly into an activated virtual environment:
+
+> [!WARNING]  
+> If your host machine is on arm64 architecture(including Apple silicon machines, equipped with m1/m2 processors), there are some issues when installing `grpcio` within `conda` environment. You will have to manually build and install it like below. Read more about this issue [here](https://github.com/grpc/grpc/issues/33714).
+```bash
+$ GRPC_PYTHON_LDFLAGS=" -framework CoreFoundation" pip install grpcio --no-binary :all:
+```
 
 ```text
 $ pip install instill-sdk
@@ -34,13 +39,47 @@ $ poetry add instill-sdk
 
 ## Usage
 
-After installation, the package can be imported:
+### Check import
+After installation, you can check if it has been installed correctly:
 
 ```text
 $ python
 >>> import instill
 >>> instill.__version__
 ```
+
+### Config `Instill Core` or `Instill Cloud` instance
+Before we can start using this SDK, you will need to create and fill the host related configs, currently the config file path is `${HOME}/.config/instill/config.yaml`
+
+Within the config file, you can define multiple instances with the `alias` of your liking, later in the SDK you can refer to this `alias` to switch between the instance.
+> [!NOTE]  
+> You will want to have exactly one instance named `default`. The SDK will look for this as a default value, and later on you can swtich to other instances you specified in the config.
+```yaml
+hosts:
+  alias1:
+    url:    str
+    secure: bool
+    token:  str
+  alias2:
+    url:    str
+    secure: bool
+    token:  str
+  ...
+  ...
+```
+Example:
+```yaml
+hosts:
+  default:
+    url: localhost:8080
+    secure: false
+    token: instill_sk***
+  cloud:
+    url: api.instill.tech
+    secure: true
+    token: instill_sk***
+```
+
 
 ### You can find a [_notebook example_](notebooks/model_usage.ipynb) here
 

--- a/instill/clients/connector.py
+++ b/instill/clients/connector.py
@@ -26,23 +26,21 @@ class ConnectorClient(Client):
         self.metadata: str = ""
 
         if global_config.hosts is not None:
-            for instance in global_config.hosts.keys():
-                if instance == "default":
+            for instance, config in global_config.hosts.items():
+                if not config.secure:
                     self.metadata = (
                         (
                             "authorization",
-                            f"Bearer {global_config.hosts[instance].token}",
+                            f"Bearer {config.token}",
                         ),
                     )
-                    channel = grpc.insecure_channel(global_config.hosts[instance].url)
+                    channel = grpc.insecure_channel(config.url)
                 else:
                     ssl_creds = grpc.ssl_channel_credentials()
-                    call_creds = grpc.access_token_call_credentials(
-                        global_config.hosts[instance].token
-                    )
+                    call_creds = grpc.access_token_call_credentials(config.token)
                     creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
                     channel = grpc.secure_channel(
-                        target=global_config.hosts[instance].url,
+                        target=config.url,
                         credentials=creds,
                     )
                 self.hosts[instance]["channel"] = channel

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -21,23 +21,21 @@ class MgmtClient(Client):
         self.metadata: str = ""
 
         if global_config.hosts is not None:
-            for instance in global_config.hosts.keys():
-                if instance == "default":
+            for instance, config in global_config.hosts.items():
+                if not config.secure:
                     self.metadata = (
                         (
                             "authorization",
-                            f"Bearer {global_config.hosts[instance].token}",
+                            f"Bearer {config.token}",
                         ),
                     )
-                    channel = grpc.insecure_channel(global_config.hosts[instance].url)
+                    channel = grpc.insecure_channel(config.url)
                 else:
                     ssl_creds = grpc.ssl_channel_credentials()
-                    call_creds = grpc.access_token_call_credentials(
-                        global_config.hosts[instance].token
-                    )
+                    call_creds = grpc.access_token_call_credentials(config.token)
                     creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
                     channel = grpc.secure_channel(
-                        target=global_config.hosts[instance].url,
+                        target=config.url,
                         credentials=creds,
                     )
                 self.hosts[instance]["channel"] = channel

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -25,23 +25,21 @@ class ModelClient(Client):
         self.metadata: str = ""
 
         if global_config.hosts is not None:
-            for instance in global_config.hosts.keys():
-                if instance == "default":
+            for instance, config in global_config.hosts.items():
+                if not config.secure:
                     self.metadata = (
                         (
                             "authorization",
-                            f"Bearer {global_config.hosts[instance].token}",
+                            f"Bearer {config.token}",
                         ),
                     )
-                    channel = grpc.insecure_channel(global_config.hosts[instance].url)
+                    channel = grpc.insecure_channel(config.url)
                 else:
                     ssl_creds = grpc.ssl_channel_credentials()
-                    call_creds = grpc.access_token_call_credentials(
-                        global_config.hosts[instance].token
-                    )
+                    call_creds = grpc.access_token_call_credentials(config.token)
                     creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
                     channel = grpc.secure_channel(
-                        target=global_config.hosts[instance].url,
+                        target=config.url,
                         credentials=creds,
                     )
                 self.hosts[instance]["channel"] = channel

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -26,23 +26,21 @@ class PipelineClient(Client):
         self.metadata: str = ""
 
         if global_config.hosts is not None:
-            for instance in global_config.hosts.keys():
-                if instance == "default":
+            for instance, config in global_config.hosts.items():
+                if not config.secure:
                     self.metadata = (
                         (
                             "authorization",
-                            f"Bearer {global_config.hosts[instance].token}",
+                            f"Bearer {config.token}",
                         ),
                     )
-                    channel = grpc.insecure_channel(global_config.hosts[instance].url)
+                    channel = grpc.insecure_channel(config.url)
                 else:
                     ssl_creds = grpc.ssl_channel_credentials()
-                    call_creds = grpc.access_token_call_credentials(
-                        global_config.hosts[instance].token
-                    )
+                    call_creds = grpc.access_token_call_credentials(config.token)
                     creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
                     channel = grpc.secure_channel(
-                        target=global_config.hosts[instance].url,
+                        target=config.url,
                         credentials=creds,
                     )
                 self.hosts[instance]["channel"] = channel

--- a/instill/configuration/__init__.py
+++ b/instill/configuration/__init__.py
@@ -16,6 +16,7 @@ CONFIG_DIR = Path(
 
 class _InstillHost(BaseModel):
     url: str
+    secure: bool
     token: t.Optional[str] = ""
 
 


### PR DESCRIPTION
Because

- support both secure/insecure option in config to accommodate `Core` and `Cloud` instance

This commit

- add `secure` in config
- update `client` to adopt updated config 
