### PR TITLE
chore(clients): add token in clients

### DIFF
--- a/instill/clients/connector.py
+++ b/instill/clients/connector.py
@@ -43,6 +43,7 @@ class ConnectorClient(Client):
                         target=config.url,
                         credentials=creds,
                     )
+                self.hosts[instance]["token"] = config.token
                 self.hosts[instance]["channel"] = channel
                 self.hosts[instance][
                     "client"

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -38,6 +38,7 @@ class MgmtClient(Client):
                         target=config.url,
                         credentials=creds,
                     )
+                self.hosts[instance]["token"] = config.token
                 self.hosts[instance]["channel"] = channel
                 self.hosts[instance]["client"] = mgmt_service.MgmtPublicServiceStub(
                     channel

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -42,6 +42,7 @@ class ModelClient(Client):
                         target=config.url,
                         credentials=creds,
                     )
+                self.hosts[instance]["token"] = config.token
                 self.hosts[instance]["channel"] = channel
                 self.hosts[instance]["client"] = model_service.ModelPublicServiceStub(
                     channel

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -43,6 +43,7 @@ class PipelineClient(Client):
                         target=config.url,
                         credentials=creds,
                     )
+                self.hosts[instance]["token"] = config.token
                 self.hosts[instance]["channel"] = channel
                 self.hosts[instance][
                     "client"

--- a/instill/resources/connector_ai.py
+++ b/instill/resources/connector_ai.py
@@ -8,12 +8,13 @@ class InstillModelConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        api_token: str,
         server_url: str,
     ) -> None:
         definition = "connector-definitions/ai-instill-model"
         configuration = {
-            "api_token": api_token,
+            "api_token": client.connector_service.hosts[
+                client.connector_service.instance
+            ]["token"],
             "server_url": server_url,
         }
         super().__init__(client, name, definition, configuration)

--- a/instill/resources/connector_ai.py
+++ b/instill/resources/connector_ai.py
@@ -10,13 +10,11 @@ class InstillModelConnector(Connector):
         name: str,
         api_token: str,
         server_url: str,
-        model_name: str,
     ) -> None:
         definition = "connector-definitions/ai-instill-model"
         configuration = {
             "api_token": api_token,
             "server_url": server_url,
-            "model_id": model_name,
         }
         super().__init__(client, name, definition, configuration)
 

--- a/janky-integration-test.py
+++ b/janky-integration-test.py
@@ -85,9 +85,7 @@ try:
     mobilenet_connector = InstillModelConnector(
         client,
         "mobilenetv2",
-        client.model_serevice.hosts[client.model_serevice.instance]["token"],
         "http://model-backend:8083",
-        "users/admin/models/mobilenetv2",
     )
     assert (
         mobilenet_connector.get_state()

--- a/janky-integration-test.py
+++ b/janky-integration-test.py
@@ -3,7 +3,7 @@ from google.protobuf.struct_pb2 import Struct
 from instill.clients import get_client
 from instill.resources.model import GithubModel
 
-# from instill.resources.connector_ai import InstillModelConnector
+from instill.resources.connector_ai import InstillModelConnector
 from instill.resources.connector import Connector
 from instill.resources.pipeline import Pipeline
 import instill.protogen.model.model.v1alpha.model_pb2 as model_interface
@@ -82,7 +82,27 @@ try:
     assert client.connector_service.is_serving()
     Logger.i("connector client created, assert status == serving: True")
 
-    # mobilenet_connector = InstillModelConnector(co, "mobilenetv2_connector", "", "http://model-backend:9080", "mobilenetv2")
+    mobilenet_connector = InstillModelConnector(
+        client,
+        "mobilenetv2",
+        client.model_serevice.hosts[client.model_serevice.instance]["token"],
+        "http://model-backend:8083",
+        "users/admin/models/mobilenetv2",
+    )
+    assert (
+        mobilenet_connector.get_state()
+        == connector_interface.ConnectorResource.STATE_DISCONNECTED
+    )
+    Logger.i(
+        "instill model connector created, assert state == STATE_DISCONNECTED: True"
+    )
+
+    # assert (
+    #     mobilenet_connector.test()
+    #     == connector_interface.ConnectorResource.STATE_CONNECTED
+    # )
+    # Logger.i("instill model connector, assert state == STATE_CONNECTED: True")
+
     config = {"destination_path": "/local/test-1"}
     csv_connector = Connector(
         client,


### PR DESCRIPTION
Because

- require `api-token` when setting up instill model connector

This commit

- add `api-token` in clients
