### PR TITLE
chore(client,readme,deps):  fix client init will exit without `vdp` or `model`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ from instill.clients import get_client
 client = get_clinet()
 ```
 
+If you have not set up `Instill VDP` or `Instill Model`, you will get a warning like this
+```bash
+2023-09-27 18:49:04,871.871 WARNING  Instill VDP is not serving, VDP functionalities will not work
+2023-09-27 18:49:04,907.907 WARNING  Instill Model is not serving, Model functionalities will not work
+```
+
 You can check the readiness of each service
 
 ```python

--- a/instill/clients/client.py
+++ b/instill/clients/client.py
@@ -3,6 +3,8 @@ from instill.clients.connector import ConnectorClient
 from instill.clients.mgmt import MgmtClient
 from instill.clients.model import ModelClient
 from instill.clients.pipeline import PipelineClient
+from instill.utils.error_handler import NotServingException
+from instill.utils.logger import Logger
 
 _mgmt_client = None
 _connector_client = None
@@ -52,9 +54,21 @@ def _get_model_clinet() -> ModelClient:
 class InstillClient:
     def __init__(self) -> None:
         self.mgmt_service = _get_mgmt_client()
+        if not self.mgmt_service.is_serving():
+            Logger.w("Instill Base is required")
+            raise NotServingException
         self.connector_service = _get_connector_clinet()
         self.pipeline_service = _get_pipeline_clinet()
+        if (
+            not self.connector_service.is_serving()
+            and not self.pipeline_service.is_serving()
+        ):
+            Logger.w("Instill VDP is not serving, VDP functionalities will not work")
         self.model_service = _get_model_clinet()
+        if not self.model_service.is_serving():
+            Logger.w(
+                "Instill Model is not serving, Model functionalities will not work"
+            )
 
     def set_instance(self, instance: str):
         self.mgmt_service.instance = instance

--- a/integration-test.py
+++ b/integration-test.py
@@ -12,7 +12,6 @@ from instill.resources import (
     Pipeline,
     model_pb,
     connector_pb,
-    pipeline_pb,
     task_detection,
     create_start_operator,
     create_end_operator,


### PR DESCRIPTION
Because

- import client will cause `os._exit(1)` if `instill vdp` and `instill model` are not running, this is not desired

This commit

- add `is_serving()` check and warn the user if the functionalities for `instill vdp` or `instill model` wont work
- bump `protogen`
