### PR TITLE
chore(clients): optimize instance switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Before we can start using this SDK, you will need to create a config file under 
 
 Within the config file, you can define multiple instances with the `alias` of your liking, later in the SDK you can refer to this `alias` to switch between instances.[^2]
 
-[^2]: SDK will load the configs for `alias` named `default` when start up. So it is required to have at least one instance named `default`.
+[^2]: SDK is default to look for instance named `default` first, and will fall back to the first instance entry in the config file if `default` not found
 
 ```yaml
 hosts:
@@ -127,6 +127,14 @@ client.pipeline_service.is_serving()
 # True
 client.model_service.is_serving()
 # True
+```
+
+You can also switch to other instances
+
+```python
+client.set_instance("your-instance-in-config")
+client.mgmt_service.instance
+# 'your-instance-in-config'
 ```
 
 > [!NOTE]  

--- a/instill/clients/client.py
+++ b/instill/clients/client.py
@@ -22,7 +22,7 @@ def _get_mgmt_client() -> MgmtClient:
     return _mgmt_client
 
 
-def _get_connector_clinet() -> ConnectorClient:
+def _get_connector_client() -> ConnectorClient:
     global _connector_client
 
     if _connector_client is None:
@@ -33,7 +33,7 @@ def _get_connector_clinet() -> ConnectorClient:
     return _connector_client
 
 
-def _get_pipeline_clinet() -> PipelineClient:
+def _get_pipeline_client() -> PipelineClient:
     global _pipeline_client
 
     if _pipeline_client is None:
@@ -42,7 +42,7 @@ def _get_pipeline_clinet() -> PipelineClient:
     return _pipeline_client
 
 
-def _get_model_clinet() -> ModelClient:
+def _get_model_client() -> ModelClient:
     global _model_client
 
     if _model_client is None:
@@ -57,14 +57,14 @@ class InstillClient:
         if not self.mgmt_service.is_serving():
             Logger.w("Instill Base is required")
             raise NotServingException
-        self.connector_service = _get_connector_clinet()
-        self.pipeline_service = _get_pipeline_clinet()
+        self.connector_service = _get_connector_client()
+        self.pipeline_service = _get_pipeline_client()
         if (
             not self.connector_service.is_serving()
             and not self.pipeline_service.is_serving()
         ):
             Logger.w("Instill VDP is not serving, VDP functionalities will not work")
-        self.model_service = _get_model_clinet()
+        self.model_service = _get_model_client()
         if not self.model_service.is_serving():
             Logger.w(
                 "Instill Model is not serving, Model functionalities will not work"

--- a/instill/clients/connector.py
+++ b/instill/clients/connector.py
@@ -10,6 +10,7 @@ import instill.protogen.vdp.connector.v1alpha.connector_definition_pb2 as connec
 # connector
 import instill.protogen.vdp.connector.v1alpha.connector_pb2 as connector_interface
 import instill.protogen.vdp.connector.v1alpha.connector_public_service_pb2_grpc as connector_service
+from instill.clients import constant
 from instill.clients.base import Client
 
 # common
@@ -22,8 +23,12 @@ from instill.utils.error_handler import grpc_handler
 class ConnectorClient(Client):
     def __init__(self, namespace: str) -> None:
         self.hosts: defaultdict = defaultdict(dict)
-        self.instance = "default"
-        self.namespace = namespace
+        self.namespace: str = namespace
+        self.instance: str = (
+            constant.DEFAULT_INSTANCE
+            if constant.DEFAULT_INSTANCE in global_config.hosts.keys()
+            else list(global_config.hosts.keys())[0]
+        )
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():

--- a/instill/clients/connector.py
+++ b/instill/clients/connector.py
@@ -24,11 +24,12 @@ class ConnectorClient(Client):
     def __init__(self, namespace: str) -> None:
         self.hosts: defaultdict = defaultdict(dict)
         self.namespace: str = namespace
-        self.instance: str = (
-            constant.DEFAULT_INSTANCE
-            if constant.DEFAULT_INSTANCE in global_config.hosts.keys()
-            else list(global_config.hosts.keys())[0]
-        )
+        if constant.DEFAULT_INSTANCE in global_config.hosts:
+            self.instance = constant.DEFAULT_INSTANCE
+        elif len(global_config.hosts) == 0:
+            self.instance = ""
+        else:
+            self.instance = list(global_config.hosts.keys())[0]
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():

--- a/instill/clients/constant.py
+++ b/instill/clients/constant.py
@@ -1,0 +1,1 @@
+DEFAULT_INSTANCE: str = "default"

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -3,10 +3,14 @@ from collections import defaultdict
 
 import grpc
 
+# mgmt
 import instill.protogen.base.mgmt.v1alpha.metric_pb2 as metric_interface
 import instill.protogen.base.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill.protogen.base.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
 import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
+from instill.clients import constant
+
+# common
 from instill.clients.base import Client
 from instill.configuration import global_config
 from instill.utils.error_handler import grpc_handler
@@ -17,7 +21,11 @@ from instill.utils.error_handler import grpc_handler
 class MgmtClient(Client):
     def __init__(self) -> None:
         self.hosts: defaultdict = defaultdict(dict)
-        self.instance: str = "default"
+        self.instance: str = (
+            constant.DEFAULT_INSTANCE
+            if constant.DEFAULT_INSTANCE in global_config.hosts
+            else list(global_config.hosts.keys())[0]
+        )
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -21,11 +21,12 @@ from instill.utils.error_handler import grpc_handler
 class MgmtClient(Client):
     def __init__(self) -> None:
         self.hosts: defaultdict = defaultdict(dict)
-        self.instance: str = (
-            constant.DEFAULT_INSTANCE
-            if constant.DEFAULT_INSTANCE in global_config.hosts
-            else list(global_config.hosts.keys())[0]
-        )
+        if constant.DEFAULT_INSTANCE in global_config.hosts:
+            self.instance = constant.DEFAULT_INSTANCE
+        elif len(global_config.hosts) == 0:
+            self.instance = ""
+        else:
+            self.instance = list(global_config.hosts.keys())[0]
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -23,11 +23,12 @@ class ModelClient(Client):
     def __init__(self, namespace: str) -> None:
         self.hosts: defaultdict = defaultdict(dict)
         self.namespace: str = namespace
-        self.instance: str = (
-            constant.DEFAULT_INSTANCE
-            if constant.DEFAULT_INSTANCE in global_config.hosts
-            else list(global_config.hosts.keys())[0]
-        )
+        if constant.DEFAULT_INSTANCE in global_config.hosts:
+            self.instance = constant.DEFAULT_INSTANCE
+        elif len(global_config.hosts) == 0:
+            self.instance = ""
+        else:
+            self.instance = list(global_config.hosts.keys())[0]
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -11,6 +11,7 @@ import instill.protogen.model.model.v1alpha.model_definition_pb2 as model_defini
 # model
 import instill.protogen.model.model.v1alpha.model_pb2 as model_interface
 import instill.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
+from instill.clients import constant
 from instill.clients.base import Client
 
 # common
@@ -21,8 +22,12 @@ from instill.utils.error_handler import grpc_handler
 class ModelClient(Client):
     def __init__(self, namespace: str) -> None:
         self.hosts: defaultdict = defaultdict(dict)
-        self.instance: str = "default"
         self.namespace: str = namespace
+        self.instance: str = (
+            constant.DEFAULT_INSTANCE
+            if constant.DEFAULT_INSTANCE in global_config.hosts
+            else list(global_config.hosts.keys())[0]
+        )
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -23,11 +23,12 @@ class PipelineClient(Client):
     def __init__(self, namespace: str) -> None:
         self.hosts: defaultdict = defaultdict(dict)
         self.namespace: str = namespace
-        self.instance: str = (
-            constant.DEFAULT_INSTANCE
-            if constant.DEFAULT_INSTANCE in global_config.hosts
-            else list(global_config.hosts.keys())[0]
-        )
+        if constant.DEFAULT_INSTANCE in global_config.hosts:
+            self.instance = constant.DEFAULT_INSTANCE
+        elif len(global_config.hosts) == 0:
+            self.instance = ""
+        else:
+            self.instance = list(global_config.hosts.keys())[0]
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -9,6 +9,7 @@ import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthchec
 # pipeline
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_pb2 as pipeline_interface
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
+from instill.clients import constant
 
 # common
 from instill.clients.base import Client
@@ -21,8 +22,12 @@ from instill.utils.error_handler import grpc_handler
 class PipelineClient(Client):
     def __init__(self, namespace: str) -> None:
         self.hosts: defaultdict = defaultdict(dict)
-        self.instance: str = "default"
         self.namespace: str = namespace
+        self.instance: str = (
+            constant.DEFAULT_INSTANCE
+            if constant.DEFAULT_INSTANCE in global_config.hosts
+            else list(global_config.hosts.keys())[0]
+        )
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():

--- a/instill/configuration/__init__.py
+++ b/instill/configuration/__init__.py
@@ -17,11 +17,11 @@ CONFIG_DIR = Path(
 class _InstillHost(BaseModel):
     url: str
     secure: bool
-    token: t.Optional[str] = ""
+    token: str
 
 
 class _Config(BaseModel):
-    hosts: t.Optional[t.Dict[str, _InstillHost]] = None
+    hosts: t.Dict[str, _InstillHost] = {}
 
 
 class Configuration:
@@ -31,7 +31,7 @@ class Configuration:
         CONFIG_DIR.mkdir(exist_ok=True)
 
     @property
-    def hosts(self) -> t.Optional[t.Dict[str, _InstillHost]]:
+    def hosts(self) -> t.Dict[str, _InstillHost]:
         return self._config.hosts
 
     def load(self) -> None:

--- a/instill/tests/test_client.py
+++ b/instill/tests/test_client.py
@@ -9,13 +9,13 @@ def describe_client():
     def describe_instance():
         def when_not_set(expect):
             mgmt_client = MgmtClient()
-            expect(mgmt_client.instance) == "default"
+            expect(mgmt_client.instance) == ""
             model_client = ModelClient(namespace="")
-            expect(model_client.instance) == "default"
+            expect(model_client.instance) == ""
             pipeline_client = PipelineClient(namespace="")
-            expect(pipeline_client.instance) == "default"
+            expect(pipeline_client.instance) == ""
             connector_client = ConnectorClient(namespace="")
-            expect(connector_client.instance) == "default"
+            expect(connector_client.instance) == ""
 
         def when_set_correct_type(expect):
             mgmt_client = MgmtClient()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,13 +9,13 @@ def describe_client():
     def describe_instance():
         def when_not_set(expect):
             mgmt_client = MgmtClient()
-            expect(mgmt_client.instance) == "default"
+            expect(mgmt_client.instance) == ""
             model_client = ModelClient(namespace="")
-            expect(model_client.instance) == "default"
+            expect(model_client.instance) == ""
             pipeline_client = PipelineClient(namespace="")
-            expect(pipeline_client.instance) == "default"
+            expect(pipeline_client.instance) == ""
             connector_client = ConnectorClient(namespace="")
-            expect(connector_client.instance) == "default"
+            expect(connector_client.instance) == ""
 
         def when_set_correct_type(expect):
             mgmt_client = MgmtClient()


### PR DESCRIPTION
Because

- avoid error exit if `default` instance not found

This commit

- fallback to the first instance entry in config file if `default` not found
