### PR TITLE
refactor(config)!: update config file path to avoid collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ python
 
 ### Config `Instill Core` or `Instill Cloud` instance
 
-Before we can start using this SDK, you will need to create a config file under this path `${HOME}/.config/instill/config.yaml`, and within that path you will need to fill in some basic parameters for your desired host.[^1]
+Before we can start using this SDK, you will need to create a config file under this path `${HOME}/.config/instill/sdk/python/config.yaml`, and within that path you will need to fill in some basic parameters for your desired host.[^1]
 
 [^1]: You can obtain an `api_token`, by simply going to Settings > API Tokens page from the console, no matter it is `Instill Core` or `Instill Cloud`.
 

--- a/instill/configuration/__init__.py
+++ b/instill/configuration/__init__.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 CONFIG_DIR = Path(
     os.getenv(
         "INSTILL_SYSTEM_CONFIG_PATH",
-        Path.home() / ".config/instill/",
+        Path.home() / ".config/instill/sdk/python/",
     )
 )
 

--- a/instill/utils/logger.py
+++ b/instill/utils/logger.py
@@ -9,8 +9,8 @@ class Logger:
 
     @staticmethod
     def initialize(
-        runlog_path=f"{home_dir}/.config/instill/run.log",
-        errorlog_path=f"{home_dir}/.config/instill/error.log",
+        runlog_path=f"{home_dir}/.config/instill/sdk/python/run.log",
+        errorlog_path=f"{home_dir}/.config/instill/sdk/python/error.log",
     ):
         os.makedirs(os.path.dirname(runlog_path), exist_ok=True)
         os.makedirs(os.path.dirname(errorlog_path), exist_ok=True)


### PR DESCRIPTION
Because

- avoid path collision with other `Instill` product config file

This commit

- update config file path to have product scope prefixes: `sdk/python`
