### PR TITLE
ci(workflows): fix wrong rc version when minor version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
         id: get-rc-version
         continue-on-error: true
         run: |
-          rc_version=$(curl -s https://pypi.org/pypi/instill-sdk/json | jq '.releases | keys' | sort -V | tr -d '[]"", ' | sed '/^$/d' | tail -1 | grep -Eo 'rc[0-9]' | grep -Eo '[0-9]+$')
+          rc_version=$(curl -s https://pypi.org/pypi/instill-sdk/json | jq '.releases | keys' | sort -V | tr -d '[]"", ' | sed '/^$/d' | tail -1 | grep -Eo ''$(poetry version -s)'rc[0-9]+$' | grep -Eo '[0-9]+$')
           echo "rc_version=$rc_version" >> $GITHUB_OUTPUT
 
       - name: Tag rc version


### PR DESCRIPTION
Because

- wrong `rc` tag when major or minor version bump

This commit

- update get rc version command
