### PR TITLE
fix(client)!: fix wrongful delete of resources and connection not close

### DIFF
--- a/instill/clients/client.py
+++ b/instill/clients/client.py
@@ -76,6 +76,20 @@ class InstillClient:
         self.pipeline_service.instance = instance
         self.model_service.instance = instance
 
+    def close(self):
+        if self.mgmt_service.is_serving():
+            for host in self.mgmt_service.hosts.values():
+                host["channel"].close()
+        if self.connector_service.is_serving():
+            for host in self.connector_service.hosts.values():
+                host["channel"].close()
+        if self.pipeline_service.is_serving():
+            for host in self.pipeline_service.hosts.values():
+                host["channel"].close()
+        if self.model_service.is_serving():
+            for host in self.model_service.hosts.values():
+                host["channel"].close()
+
 
 def get_client() -> InstillClient:
     global _client

--- a/instill/resources/connector.py
+++ b/instill/resources/connector.py
@@ -28,10 +28,6 @@ class Connector(Resource):
 
         self.resource = connector
 
-    def __del__(self):
-        if self.resource is not None:
-            self.client.connector_service.delete_connector(self.resource.id)
-
     def __call__(self, task_inputs: list, mode="execute") -> list:
         if mode == "execute":
             return self.client.connector_service.execute_connector(
@@ -73,3 +69,7 @@ class Connector(Resource):
 
     def test(self) -> connector_interface.ConnectorResource.State:
         return self.client.connector_service.test_connector(self.resource.id)
+
+    def delete(self):
+        if self.resource is not None:
+            self.client.connector_service.delete_connector(self.resource.id)

--- a/instill/resources/model.py
+++ b/instill/resources/model.py
@@ -27,10 +27,6 @@ class Model(Resource):
 
         self.resource = model
 
-    def __del__(self):
-        if self.resource is not None:
-            self.client.model_service.delete_model(self.resource.id)
-
     def __call__(self, task_inputs: list) -> list:
         return self.client.model_service.trigger_model(self.resource.id, task_inputs)
 
@@ -71,6 +67,10 @@ class Model(Resource):
         self.client.model_service.undeploy_model(self.resource.id)
         self._update()
         return self._resource
+
+    def delete(self):
+        if self.resource is not None:
+            self.client.model_service.delete_model(self.resource.id)
 
 
 class GithubModel(Model):

--- a/instill/resources/pipeline.py
+++ b/instill/resources/pipeline.py
@@ -23,10 +23,6 @@ class Pipeline(Resource):
 
         self.resource = pipeline
 
-    def __del__(self):
-        if self.resource is not None:
-            self.client.pipeline_service.delete_pipeline(self.resource.id)
-
     def __call__(
         self, task_inputs: list
     ) -> Tuple[list, pipeline_interface.TriggerMetadata]:
@@ -58,3 +54,7 @@ class Pipeline(Resource):
 
     def validate_pipeline(self) -> pipeline_interface.Pipeline:
         return self.client.pipeline_service.validate_pipeline(name=self.resource.id)
+
+    def delete(self):
+        if self.resource is not None:
+            self.client.pipeline_service.delete_pipeline(self.resource.id)


### PR DESCRIPTION
Because

- grpc channel not close
- overwriting `_del_` is a will cause resource deletion after script finish

This commit

- move resource function `_del_` to `delete`
- close grpc channels propely
