### PR TITLE
fix(config,pipeline): allow no config file and fix required pipeline recipe

### DIFF
--- a/instill/configuration/__init__.py
+++ b/instill/configuration/__init__.py
@@ -65,10 +65,10 @@ class Configuration:
                 c,
             )
 
-    def set_token(self, alias: str, token: str) -> None:
-        if self._config.hosts is not None:
-            self._config.hosts[alias].token = token
-            self.save()
+    def set_default(self, url: str, token: str, secure: bool):
+        self._config.hosts["default"] = _InstillHost(
+            url=url, secure=secure, token=token
+        )
 
 
 global_config = Configuration()

--- a/instill/resources/pipeline.py
+++ b/instill/resources/pipeline.py
@@ -11,7 +11,7 @@ class Pipeline(Resource):
         self,
         client: InstillClient,
         name: str,
-        recipe: pipeline_interface.Recipe,
+        recipe: pipeline_interface.Recipe | None = None,
     ) -> None:
         super().__init__()
         self.client = client


### PR DESCRIPTION
Because

- allow better user experience when setting target host and api token 

This commit

- make config file optional and allow setting default host and api token during runtime
- fix mandatory `recipe` argument even with existing resource
- bump protogen-python version

Resolves INS-2505