### PR TITLE
chore(makefile): remove proto updating from install target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ VIRTUAL_ENV ?= .venv
 DEPENDENCIES := $(VIRTUAL_ENV)/.poetry-$(shell bin/checksum pyproject.toml poetry.lock)
 
 .PHONY: install
-install: $(DEPENDENCIES) .cache proto ## Install project dependencies
+install: $(DEPENDENCIES) .cache ## Install project dependencies
 
 $(DEPENDENCIES): poetry.lock
 	@ rm -rf $(VIRTUAL_ENV)/.poetry-*
@@ -41,6 +41,7 @@ endif
 .cache:
 	@ mkdir -p .cache
 
+.PHONY: proto
 proto:
 	@ git submodule update --init --recursive
 	@ git submodule update --remote --merge


### PR DESCRIPTION
Because

- avoid auto-updating `protogen-python` version when triggering `install` target

This commit

- move `proto` to independent target
