### PR TITLE
feat(client)!: support asyncio and add better client type hint

### DIFF
--- a/instill/clients/__init__.py
+++ b/instill/clients/__init__.py
@@ -1,4 +1,4 @@
-from instill.clients.client import InstillClient, get_client
+from instill.clients.client import InstillClient
 from instill.clients.mgmt import MgmtClient
 from instill.clients.model import ModelClient
 from instill.clients.pipeline import PipelineClient

--- a/instill/clients/__init__.py
+++ b/instill/clients/__init__.py
@@ -1,4 +1,4 @@
-from instill.clients.client import InstillClient
+from instill.clients.client import InstillClient, get_client
 from instill.clients.mgmt import MgmtClient
 from instill.clients.model import ModelClient
 from instill.clients.pipeline import PipelineClient

--- a/instill/clients/base.py
+++ b/instill/clients/base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Union
 
 import google.protobuf.message
 import grpc
@@ -57,7 +58,7 @@ class Client(ABC):
 class RequestFactory:
     def __init__(
         self,
-        method: grpc.UnaryUnaryMultiCallable,
+        method: Union[grpc.UnaryUnaryMultiCallable, grpc.StreamUnaryMultiCallable],
         request: google.protobuf.message.Message,
         metadata,
     ) -> None:
@@ -67,6 +68,12 @@ class RequestFactory:
 
     def send_sync(self):
         return self.method(request=self.request, metadata=self.metadata)
+
+    def send_stream(self):
+        return self.method(
+            request_iterator=iter([self.request]),
+            metadata=self.metadata,
+        )
 
     async def send_async(self):
         return await self.method(request=self.request, metadata=self.metadata)

--- a/instill/clients/base.py
+++ b/instill/clients/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
-import grpc
 import google.protobuf.message
+import grpc
 
 
 class Client(ABC):

--- a/instill/clients/base.py
+++ b/instill/clients/base.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
 
+import grpc
+import google.protobuf.message
+
 
 class Client(ABC):
     """Base interface class for creating mgmt/pipeline/connector/model clients.
@@ -49,3 +52,21 @@ class Client(ABC):
     @abstractmethod
     def is_serving(self):
         raise NotImplementedError
+
+
+class RequestFactory:
+    def __init__(
+        self,
+        method: grpc.UnaryUnaryMultiCallable,
+        request: google.protobuf.message.Message,
+        metadata,
+    ) -> None:
+        self.method = method
+        self.request = request
+        self.metadata = metadata
+
+    def send_sync(self):
+        return self.method(request=self.request, metadata=self.metadata)
+
+    async def send_async(self):
+        return await self.method(request=self.request, metadata=self.metadata)

--- a/instill/clients/client.py
+++ b/instill/clients/client.py
@@ -13,13 +13,13 @@ class InstillClient:
             Logger.w("Instill Core is required")
             raise NotServingException
         self.pipeline_service = PipelineClient(
-            namespace=self.mgmt_service.get_user().name,
+            namespace=self.mgmt_service.get_user().user.name,
             async_enabled=async_enabled,
         )
         if not self.pipeline_service.is_serving():
             Logger.w("Instill VDP is not serving, VDP functionalities will not work")
         self.model_service = ModelClient(
-            namespace=self.mgmt_service.get_user().name,
+            namespace=self.mgmt_service.get_user().user.name,
             async_enabled=async_enabled,
         )
         if not self.model_service.is_serving():

--- a/instill/clients/client.py
+++ b/instill/clients/client.py
@@ -7,20 +7,20 @@ from instill.utils.logger import Logger
 
 
 class InstillClient:
-    def __init__(self, asyncio: bool = False) -> None:
-        self.mgmt_service = MgmtClient(asyncio=asyncio)
+    def __init__(self, async_enabled: bool = False) -> None:
+        self.mgmt_service = MgmtClient(async_enabled=async_enabled)
         if not self.mgmt_service.is_serving():
             Logger.w("Instill Core is required")
             raise NotServingException
         self.pipeline_service = PipelineClient(
             namespace=self.mgmt_service.get_user().name,
-            asyncio=asyncio,
+            async_enabled=async_enabled,
         )
         if not self.pipeline_service.is_serving():
             Logger.w("Instill VDP is not serving, VDP functionalities will not work")
         self.model_service = ModelClient(
             namespace=self.mgmt_service.get_user().name,
-            asyncio=asyncio,
+            async_enabled=async_enabled,
         )
         if not self.model_service.is_serving():
             Logger.w(
@@ -55,5 +55,5 @@ class InstillClient:
                 await host.async_channel.close()
 
 
-def get_client(asyncio: bool = False) -> InstillClient:
-    return InstillClient(asyncio=asyncio)
+def get_client(async_enabled: bool = False) -> InstillClient:
+    return InstillClient(async_enabled=async_enabled)

--- a/instill/clients/client.py
+++ b/instill/clients/client.py
@@ -5,49 +5,19 @@ from instill.clients.pipeline import PipelineClient
 from instill.utils.error_handler import NotServingException
 from instill.utils.logger import Logger
 
-_mgmt_client = None
-_pipeline_client = None
-_model_client = None
-_client = None
-
-
-def _get_mgmt_client() -> MgmtClient:
-    global _mgmt_client
-
-    if _mgmt_client is None:
-        _mgmt_client = MgmtClient()
-
-    return _mgmt_client
-
-
-def _get_pipeline_client() -> PipelineClient:
-    global _pipeline_client
-
-    if _pipeline_client is None:
-        _pipeline_client = PipelineClient(namespace=_get_mgmt_client().get_user().name)
-
-    return _pipeline_client
-
-
-def _get_model_client() -> ModelClient:
-    global _model_client
-
-    if _model_client is None:
-        _model_client = ModelClient(namespace=_get_mgmt_client().get_user().name)
-
-    return _model_client
-
 
 class InstillClient:
     def __init__(self) -> None:
-        self.mgmt_service = _get_mgmt_client()
+        self.mgmt_service = MgmtClient()
         if not self.mgmt_service.is_serving():
             Logger.w("Instill Core is required")
             raise NotServingException
-        self.pipeline_service = _get_pipeline_client()
+        self.pipeline_service = PipelineClient(
+            namespace=self.mgmt_service.get_user().name
+        )
         if not self.pipeline_service.is_serving():
             Logger.w("Instill VDP is not serving, VDP functionalities will not work")
-        self.model_service = _get_model_client()
+        self.model_service = ModelClient(namespace=self.mgmt_service.get_user().name)
         if not self.model_service.is_serving():
             Logger.w(
                 "Instill Model is not serving, Model functionalities will not work"
@@ -61,19 +31,17 @@ class InstillClient:
     def close(self):
         if self.mgmt_service.is_serving():
             for host in self.mgmt_service.hosts.values():
-                host["channel"].close()
+                host.channel.close()
+                host.async_channel.close()
         if self.pipeline_service.is_serving():
             for host in self.pipeline_service.hosts.values():
-                host["channel"].close()
+                host.channel.close()
+                host.async_channel.close()
         if self.model_service.is_serving():
             for host in self.model_service.hosts.values():
-                host["channel"].close()
+                host.channel.close()
+                host.async_channel.close()
 
 
 def get_client() -> InstillClient:
-    global _client
-
-    if _client is None:
-        _client = InstillClient()
-
-    return _client
+    return InstillClient()

--- a/instill/clients/instance.py
+++ b/instill/clients/instance.py
@@ -8,10 +8,11 @@ import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as
 
 
 class InstillInstance:
-    def __init__(self, stub, url: str, token: str, secure: bool, asyncio: bool):
+    def __init__(self, stub, url: str, token: str, secure: bool, async_enabled: bool):
         self.url: str = url
         self.token: str = token
-        self.asyncio: bool = asyncio
+        self.async_enabled: bool = async_enabled
+        self.metadata: Union[str, tuple] = ""
         if not secure:
             channel = grpc.insecure_channel(url)
             self.metadata = (
@@ -20,15 +21,14 @@ class InstillInstance:
                     f"Bearer {token}",
                 ),
             )
-            if asyncio:
+            if async_enabled:
                 async_channel = grpc.aio.insecure_channel(url)
         else:
             ssl_creds = grpc.ssl_channel_credentials()
             call_creds = grpc.access_token_call_credentials(token)
             creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
             channel = grpc.secure_channel(target=url, credentials=creds)
-            self.metadata = (("", ""),)
-            if asyncio:
+            if async_enabled:
                 async_channel = grpc.aio.secure_channel(target=url, credentials=creds)
         self.channel: grpc.Channel = channel
         self.client: Union[
@@ -36,7 +36,7 @@ class InstillInstance:
             pipeline_service.PipelinePublicServiceStub,
             mgmt_service.MgmtPublicServiceStub,
         ] = stub(channel)
-        if asyncio:
+        if async_enabled:
             self.async_channel: grpc.Channel = async_channel
             self.async_client: Union[
                 model_service.ModelPublicServiceStub,

--- a/instill/clients/instance.py
+++ b/instill/clients/instance.py
@@ -1,0 +1,40 @@
+from typing import Union
+import grpc
+
+
+import instill.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
+import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
+import instill.protogen.core.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
+
+
+class InstillInstance:
+    def __init__(self, url: str, token: str, secure: bool, stub):
+        self.token: str = token
+        if not secure:
+            channel = grpc.insecure_channel(url)
+            async_channel = grpc.aio.insecure_channel(url)
+            self.metadata = (
+                (
+                    "authorization",
+                    f"Bearer {token}",
+                ),
+            )
+        else:
+            ssl_creds = grpc.ssl_channel_credentials()
+            call_creds = grpc.access_token_call_credentials(token)
+            creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
+            channel = grpc.secure_channel(target=url, credentials=creds)
+            async_channel = grpc.aio.secure_channel(target=url, credentials=creds)
+            self.metadata = ""
+        self.channel: grpc.Channel = channel
+        self.async_channel: grpc.Channel = async_channel
+        self.client: Union[
+            model_service.ModelPublicServiceStub,
+            pipeline_service.PipelinePublicServiceStub,
+            mgmt_service.MgmtPublicServiceStub,
+        ] = stub(channel)
+        self.async_client: Union[
+            model_service.ModelPublicServiceStub,
+            pipeline_service.PipelinePublicServiceStub,
+            mgmt_service.MgmtPublicServiceStub,
+        ] = stub(async_channel)

--- a/instill/clients/instance.py
+++ b/instill/clients/instance.py
@@ -1,14 +1,15 @@
 from typing import Union
+
 import grpc
 
-
+import instill.protogen.core.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
 import instill.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
-import instill.protogen.core.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
 
 
 class InstillInstance:
     def __init__(self, stub, url: str, token: str, secure: bool, asyncio: bool):
+        self.url: str = url
         self.token: str = token
         self.asyncio: bool = asyncio
         if not secure:
@@ -26,7 +27,7 @@ class InstillInstance:
             call_creds = grpc.access_token_call_credentials(token)
             creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
             channel = grpc.secure_channel(target=url, credentials=creds)
-            self.metadata = ""
+            self.metadata = (("", ""),)
             if asyncio:
                 async_channel = grpc.aio.secure_channel(target=url, credentials=creds)
         self.channel: grpc.Channel = channel

--- a/instill/clients/instance.py
+++ b/instill/clients/instance.py
@@ -8,33 +8,37 @@ import instill.protogen.core.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_s
 
 
 class InstillInstance:
-    def __init__(self, url: str, token: str, secure: bool, stub):
+    def __init__(self, stub, url: str, token: str, secure: bool, asyncio: bool):
         self.token: str = token
+        self.asyncio: bool = asyncio
         if not secure:
             channel = grpc.insecure_channel(url)
-            async_channel = grpc.aio.insecure_channel(url)
             self.metadata = (
                 (
                     "authorization",
                     f"Bearer {token}",
                 ),
             )
+            if asyncio:
+                async_channel = grpc.aio.insecure_channel(url)
         else:
             ssl_creds = grpc.ssl_channel_credentials()
             call_creds = grpc.access_token_call_credentials(token)
             creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
             channel = grpc.secure_channel(target=url, credentials=creds)
-            async_channel = grpc.aio.secure_channel(target=url, credentials=creds)
             self.metadata = ""
+            if asyncio:
+                async_channel = grpc.aio.secure_channel(target=url, credentials=creds)
         self.channel: grpc.Channel = channel
-        self.async_channel: grpc.Channel = async_channel
         self.client: Union[
             model_service.ModelPublicServiceStub,
             pipeline_service.PipelinePublicServiceStub,
             mgmt_service.MgmtPublicServiceStub,
         ] = stub(channel)
-        self.async_client: Union[
-            model_service.ModelPublicServiceStub,
-            pipeline_service.PipelinePublicServiceStub,
-            mgmt_service.MgmtPublicServiceStub,
-        ] = stub(async_channel)
+        if asyncio:
+            self.async_channel: grpc.Channel = async_channel
+            self.async_client: Union[
+                model_service.ModelPublicServiceStub,
+                pipeline_service.PipelinePublicServiceStub,
+                mgmt_service.MgmtPublicServiceStub,
+            ] = stub(async_channel)

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -18,7 +18,7 @@ from instill.utils.error_handler import grpc_handler
 
 
 class MgmtClient(Client):
-    def __init__(self) -> None:
+    def __init__(self, asyncio: bool) -> None:
         self.hosts: Dict[str, InstillInstance] = {}
         if DEFAULT_INSTANCE in global_config.hosts:
             self.instance = DEFAULT_INSTANCE
@@ -30,10 +30,11 @@ class MgmtClient(Client):
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():
                 self.hosts[instance] = InstillInstance(
-                    config.url,
-                    config.token,
-                    config.secure,
                     mgmt_service.MgmtPublicServiceStub,
+                    url=config.url,
+                    token=config.token,
+                    secure=config.secure,
+                    asyncio=asyncio,
                 )
 
     @property

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -1,17 +1,15 @@
 # pylint: disable=no-member,wrong-import-position
-from collections import defaultdict
-
-import grpc
-
+from typing import Dict
 import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 
 # mgmt
 import instill.protogen.core.mgmt.v1alpha.metric_pb2 as metric_interface
 import instill.protogen.core.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill.protogen.core.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
-from instill.clients import constant
 
 # common
+from instill.clients.constant import DEFAULT_INSTANCE
+from instill.clients.instance import InstillInstance
 from instill.clients.base import Client
 from instill.configuration import global_config
 from instill.utils.error_handler import grpc_handler
@@ -21,9 +19,9 @@ from instill.utils.error_handler import grpc_handler
 
 class MgmtClient(Client):
     def __init__(self) -> None:
-        self.hosts: defaultdict = defaultdict(dict)
-        if constant.DEFAULT_INSTANCE in global_config.hosts:
-            self.instance = constant.DEFAULT_INSTANCE
+        self.hosts: Dict[str, InstillInstance] = {}
+        if DEFAULT_INSTANCE in global_config.hosts:
+            self.instance = DEFAULT_INSTANCE
         elif len(global_config.hosts) == 0:
             self.instance = ""
         else:
@@ -31,27 +29,11 @@ class MgmtClient(Client):
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():
-                if not config.secure:
-                    channel = grpc.insecure_channel(config.url)
-                    self.hosts[instance]["metadata"] = (
-                        (
-                            "authorization",
-                            f"Bearer {config.token}",
-                        ),
-                    )
-                else:
-                    ssl_creds = grpc.ssl_channel_credentials()
-                    call_creds = grpc.access_token_call_credentials(config.token)
-                    creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
-                    channel = grpc.secure_channel(
-                        target=config.url,
-                        credentials=creds,
-                    )
-                    self.hosts[instance]["metadata"] = ""
-                self.hosts[instance]["token"] = config.token
-                self.hosts[instance]["channel"] = channel
-                self.hosts[instance]["client"] = mgmt_service.MgmtPublicServiceStub(
-                    channel
+                self.hosts[instance] = InstillInstance(
+                    config.url,
+                    config.token,
+                    config.secure,
+                    mgmt_service.MgmtPublicServiceStub,
                 )
 
     @property
@@ -79,15 +61,15 @@ class MgmtClient(Client):
         self._metadata = metadata
 
     def liveness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: mgmt_interface.LivenessResponse = self.hosts[self.instance][
-            "client"
-        ].Liveness(request=mgmt_interface.LivenessRequest())
+        resp: mgmt_interface.LivenessResponse = self.hosts[
+            self.instance
+        ].client.Liveness(request=mgmt_interface.LivenessRequest())
         return resp.health_check_response.status
 
     def readiness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: mgmt_interface.ReadinessResponse = self.hosts[self.instance][
-            "client"
-        ].Readiness(request=mgmt_interface.ReadinessRequest())
+        resp: mgmt_interface.ReadinessResponse = self.hosts[
+            self.instance
+        ].client.Readiness(request=mgmt_interface.ReadinessRequest())
         return resp.health_check_response.status
 
     def is_serving(self) -> bool:
@@ -101,9 +83,9 @@ class MgmtClient(Client):
 
     @grpc_handler
     def login(self, username="admin", password="password") -> str:
-        resp: mgmt_interface.AuthLoginResponse = self.hosts[self.instance][
-            "client"
-        ].AuthLogin(
+        resp: mgmt_interface.AuthLoginResponse = self.hosts[
+            self.instance
+        ].client.AuthLogin(
             request=mgmt_interface.AuthLoginRequest(
                 username=username, password=password
             )
@@ -112,21 +94,19 @@ class MgmtClient(Client):
 
     @grpc_handler
     def get_token(self, name: str) -> mgmt_interface.ApiToken:
-        resp: mgmt_interface.GetTokenResponse = self.hosts[self.instance][
-            "client"
-        ].GetToken(
+        resp: mgmt_interface.GetTokenResponse = self.hosts[
+            self.instance
+        ].client.GetToken(
             request=mgmt_interface.GetTokenRequest(name=name),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.token
 
     @grpc_handler
     def get_user(self) -> mgmt_interface.User:
-        resp: mgmt_interface.GetUserResponse = self.hosts[self.instance][
-            "client"
-        ].GetUser(
+        resp: mgmt_interface.GetUserResponse = self.hosts[self.instance].client.GetUser(
             request=mgmt_interface.GetUserRequest(name="users/me"),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.user
 
@@ -134,52 +114,52 @@ class MgmtClient(Client):
     def list_pipeline_trigger_records(
         self,
     ) -> metric_interface.ListPipelineTriggerRecordsResponse:
-        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
+        return self.hosts[self.instance].client.ListPipelineTriggerRecords(
             request=metric_interface.ListPipelineTriggerChartRecordsRequest(),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
     def list_pipeline_trigger_table_records(
         self,
     ) -> metric_interface.ListPipelineTriggerTableRecordsRequest:
-        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
+        return self.hosts[self.instance].client.ListPipelineTriggerRecords(
             request=metric_interface.ListPipelineTriggerTableRecordsResponse(),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
     def list_pipeline_trigger_chart_records(
         self,
     ) -> metric_interface.ListPipelineTriggerChartRecordsResponse:
-        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
+        return self.hosts[self.instance].client.ListPipelineTriggerRecords(
             request=metric_interface.ListPipelineTriggerChartRecordsRequest(),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
     def list_connector_execute_records(
         self,
     ) -> metric_interface.ListConnectorExecuteRecordsResponse:
-        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
+        return self.hosts[self.instance].client.ListPipelineTriggerRecords(
             request=metric_interface.ListConnectorExecuteRecordsRequest(),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
     def list_connector_execute_table_records(
         self,
     ) -> metric_interface.ListConnectorExecuteTableRecordsResponse:
-        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
+        return self.hosts[self.instance].client.ListPipelineTriggerRecords(
             request=metric_interface.ListConnectorExecuteTableRecordsRequest(),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
     def list_connector_execute_chart_records(
         self,
     ) -> metric_interface.ListConnectorExecuteChartRecordsResponse:
-        return self.hosts[self.instance]["client"].ListPipelineTriggerRecords(
+        return self.hosts[self.instance].client.ListPipelineTriggerRecords(
             request=metric_interface.ListConnectorExecuteChartRecordsRequest(),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -19,7 +19,7 @@ from instill.utils.error_handler import grpc_handler
 
 
 class MgmtClient(Client):
-    def __init__(self, asyncio: bool) -> None:
+    def __init__(self, async_enabled: bool) -> None:
         self.hosts: Dict[str, InstillInstance] = {}
         if DEFAULT_INSTANCE in global_config.hosts:
             self.instance = DEFAULT_INSTANCE
@@ -35,7 +35,7 @@ class MgmtClient(Client):
                     url=config.url,
                     token=config.token,
                     secure=config.secure,
-                    asyncio=asyncio,
+                    async_enabled=async_enabled,
                 )
 
     @property

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -1,16 +1,17 @@
 # pylint: disable=no-member,wrong-import-position
 from typing import Dict
+
 import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 
 # mgmt
 import instill.protogen.core.mgmt.v1alpha.metric_pb2 as metric_interface
 import instill.protogen.core.mgmt.v1alpha.mgmt_pb2 as mgmt_interface
 import instill.protogen.core.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
+from instill.clients.base import Client
 
 # common
 from instill.clients.constant import DEFAULT_INSTANCE
 from instill.clients.instance import InstillInstance
-from instill.clients.base import Client
 from instill.configuration import global_config
 from instill.utils.error_handler import grpc_handler
 

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -62,7 +62,7 @@ class MgmtClient(Client):
     def metadata(self, metadata: str):
         self._metadata = metadata
 
-    def liveness(self, async_enabled: bool = False) -> healthcheck.HealthCheckResponse:
+    def liveness(self, async_enabled: bool = False) -> mgmt_interface.LivenessResponse:
         if async_enabled:
             return RequestFactory(
                 method=self.hosts[self.instance].async_client.Liveness,
@@ -76,16 +76,16 @@ class MgmtClient(Client):
             metadata=self.hosts[self.instance].metadata,
         ).send_sync()
 
-    def readiness(self, async_enabled: bool = False) -> healthcheck.HealthCheckResponse:
+    def readiness(self, async_enabled: bool = False) -> mgmt_interface.ReadinessResponse:
         if async_enabled:
             return RequestFactory(
-                method=self.hosts[self.instance].async_client.Liveness,
+                method=self.hosts[self.instance].async_client.Readiness,
                 request=mgmt_interface.ReadinessRequest(),
                 metadata=self.hosts[self.instance].metadata,
             ).send_async()
 
         return RequestFactory(
-            method=self.hosts[self.instance].client.Liveness,
+            method=self.hosts[self.instance].client.Readiness,
             request=mgmt_interface.ReadinessRequest(),
             metadata=self.hosts[self.instance].metadata,
         ).send_sync()
@@ -93,7 +93,7 @@ class MgmtClient(Client):
     def is_serving(self) -> bool:
         try:
             return (
-                self.readiness().status
+                self.readiness().health_check_response.status
                 == healthcheck.HealthCheckResponse.SERVING_STATUS_SERVING
             )
         except Exception:

--- a/instill/clients/mgmt.py
+++ b/instill/clients/mgmt.py
@@ -76,7 +76,9 @@ class MgmtClient(Client):
             metadata=self.hosts[self.instance].metadata,
         ).send_sync()
 
-    def readiness(self, async_enabled: bool = False) -> mgmt_interface.ReadinessResponse:
+    def readiness(
+        self, async_enabled: bool = False
+    ) -> mgmt_interface.ReadinessResponse:
         if async_enabled:
             return RequestFactory(
                 method=self.hosts[self.instance].async_client.Readiness,

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -21,7 +21,7 @@ from instill.utils.error_handler import grpc_handler
 
 
 class ModelClient(Client):
-    def __init__(self, namespace: str) -> None:
+    def __init__(self, namespace: str, asyncio: bool) -> None:
         self.hosts: Dict[str, InstillInstance] = {}
         self.namespace: str = namespace
         if DEFAULT_INSTANCE in global_config.hosts:
@@ -34,10 +34,11 @@ class ModelClient(Client):
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():
                 self.hosts[instance] = InstillInstance(
-                    config.url,
-                    config.token,
-                    config.secure,
                     model_service.ModelPublicServiceStub,
+                    url=config.url,
+                    token=config.token,
+                    secure=config.secure,
+                    asyncio=asyncio,
                 )
 
     @property

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -1,21 +1,20 @@
 # pylint: disable=no-member,wrong-import-position
 import time
-from typing import Iterable, Tuple, Union, Dict
+from typing import Dict, Iterable, Tuple, Union
 
 from google.longrunning import operations_pb2
 from google.protobuf import field_mask_pb2
 
+# common
+import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
+import instill.protogen.model.model.v1alpha.model_definition_pb2 as model_definition_interface
 
 # model
 import instill.protogen.model.model.v1alpha.model_pb2 as model_interface
 import instill.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
-import instill.protogen.model.model.v1alpha.model_definition_pb2 as model_definition_interface
-
-# common
-import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
+from instill.clients.base import Client
 from instill.clients.constant import DEFAULT_INSTANCE
 from instill.clients.instance import InstillInstance
-from instill.clients.base import Client
 from instill.configuration import global_config
 from instill.utils.error_handler import grpc_handler
 

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -1,32 +1,31 @@
 # pylint: disable=no-member,wrong-import-position
 import time
-from collections import defaultdict
-from typing import Iterable, Tuple, Union
+from typing import Iterable, Tuple, Union, Dict
 
-import grpc
 from google.longrunning import operations_pb2
 from google.protobuf import field_mask_pb2
 
-import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
-import instill.protogen.model.model.v1alpha.model_definition_pb2 as model_definition_interface
 
 # model
 import instill.protogen.model.model.v1alpha.model_pb2 as model_interface
 import instill.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
-from instill.clients import constant
-from instill.clients.base import Client
+import instill.protogen.model.model.v1alpha.model_definition_pb2 as model_definition_interface
 
 # common
+import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
+from instill.clients.constant import DEFAULT_INSTANCE
+from instill.clients.instance import InstillInstance
+from instill.clients.base import Client
 from instill.configuration import global_config
 from instill.utils.error_handler import grpc_handler
 
 
 class ModelClient(Client):
     def __init__(self, namespace: str) -> None:
-        self.hosts: defaultdict = defaultdict(dict)
+        self.hosts: Dict[str, InstillInstance] = {}
         self.namespace: str = namespace
-        if constant.DEFAULT_INSTANCE in global_config.hosts:
-            self.instance = constant.DEFAULT_INSTANCE
+        if DEFAULT_INSTANCE in global_config.hosts:
+            self.instance = DEFAULT_INSTANCE
         elif len(global_config.hosts) == 0:
             self.instance = ""
         else:
@@ -34,27 +33,11 @@ class ModelClient(Client):
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():
-                if not config.secure:
-                    channel = grpc.insecure_channel(config.url)
-                    self.hosts[instance]["metadata"] = (
-                        (
-                            "authorization",
-                            f"Bearer {config.token}",
-                        ),
-                    )
-                else:
-                    ssl_creds = grpc.ssl_channel_credentials()
-                    call_creds = grpc.access_token_call_credentials(config.token)
-                    creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
-                    channel = grpc.secure_channel(
-                        target=config.url,
-                        credentials=creds,
-                    )
-                    self.hosts[instance]["metadata"] = ""
-                self.hosts[instance]["token"] = config.token
-                self.hosts[instance]["channel"] = channel
-                self.hosts[instance]["client"] = model_service.ModelPublicServiceStub(
-                    channel
+                self.hosts[instance] = InstillInstance(
+                    config.url,
+                    config.token,
+                    config.secure,
+                    model_service.ModelPublicServiceStub,
                 )
 
     @property
@@ -82,15 +65,15 @@ class ModelClient(Client):
         self._metadata = metadata
 
     def liveness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: model_interface.LivenessResponse = self.hosts[self.instance][
-            "client"
-        ].Liveness(request=model_interface.LivenessRequest())
+        resp: model_interface.LivenessResponse = self.hosts[
+            self.instance
+        ].client.Liveness(request=model_interface.LivenessRequest())
         return resp.health_check_response.status
 
     def readiness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: model_interface.ReadinessResponse = self.hosts[self.instance][
-            "client"
-        ].Readiness(request=model_interface.ReadinessRequest())
+        resp: model_interface.ReadinessResponse = self.hosts[
+            self.instance
+        ].client.Readiness(request=model_interface.ReadinessRequest())
         return resp.health_check_response.status
 
     def is_serving(self) -> bool:
@@ -104,13 +87,13 @@ class ModelClient(Client):
 
     @grpc_handler
     def watch_model(self, model_name: str) -> model_interface.Model.State.ValueType:
-        resp: model_interface.WatchUserModelResponse = self.hosts[self.instance][
-            "client"
-        ].WatchUserModel(
+        resp: model_interface.WatchUserModelResponse = self.hosts[
+            self.instance
+        ].client.WatchUserModel(
             request=model_interface.WatchUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.state
 
@@ -132,9 +115,9 @@ class ModelClient(Client):
                 parent=self.namespace, model=model, content=data
             )
         create_resp: model_interface.CreateUserModelBinaryFileUploadResponse = (
-            self.hosts[self.instance]["client"].CreateUserModelBinaryFileUpload(
+            self.hosts[self.instance].client.CreateUserModelBinaryFileUpload(
                 request_iterator=iter([req]),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
         )
 
@@ -164,11 +147,11 @@ class ModelClient(Client):
         model.configuration.update(configuration)
         create_resp: model_interface.CreateUserModelResponse = self.hosts[
             self.instance
-        ]["client"].CreateUserModel(
+        ].client.CreateUserModel(
             request=model_interface.CreateUserModelRequest(
                 model=model, parent=self.namespace
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
         while self.get_operation(name=create_resp.operation.name).done is not True:
@@ -190,11 +173,11 @@ class ModelClient(Client):
 
     @grpc_handler
     def deploy_model(self, model_name: str) -> model_interface.Model.State:
-        self.hosts[self.instance]["client"].DeployUserModel(
+        self.hosts[self.instance].client.DeployUserModel(
             request=model_interface.DeployUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
         state = self.watch_model(model_name=model_name)
@@ -206,11 +189,11 @@ class ModelClient(Client):
 
     @grpc_handler
     def undeploy_model(self, model_name: str) -> model_interface.Model.State:
-        self.hosts[self.instance]["client"].UndeployUserModel(
+        self.hosts[self.instance].client.UndeployUserModel(
             request=model_interface.UndeployUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
         state = self.watch_model(model_name=model_name)
@@ -222,35 +205,35 @@ class ModelClient(Client):
 
     @grpc_handler
     def trigger_model(self, model_name: str, task_inputs: list) -> Iterable:
-        resp: model_interface.TriggerUserModelResponse = self.hosts[self.instance][
-            "client"
-        ].TriggerUserModel(
+        resp: model_interface.TriggerUserModelResponse = self.hosts[
+            self.instance
+        ].client.TriggerUserModel(
             request=model_interface.TriggerUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}", task_inputs=task_inputs
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.task_outputs
 
     @grpc_handler
     def delete_model(self, model_name: str):
-        self.hosts[self.instance]["client"].DeleteUserModel(
+        self.hosts[self.instance].client.DeleteUserModel(
             request=model_interface.DeleteUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
     def get_model(self, model_name: str) -> model_interface.Model:
-        resp: model_interface.GetUserModelResponse = self.hosts[self.instance][
-            "client"
-        ].GetUserModel(
+        resp: model_interface.GetUserModelResponse = self.hosts[
+            self.instance
+        ].client.GetUserModel(
             request=model_interface.GetUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}",
                 view=model_definition_interface.VIEW_FULL,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.model
 
@@ -258,36 +241,36 @@ class ModelClient(Client):
     def update_model(
         self, model: model_interface.Model, mask: field_mask_pb2.FieldMask
     ) -> model_interface.Model:
-        resp: model_interface.UpdateUserModelResponse = self.hosts[self.instance][
-            "client"
-        ].UpdateUserModel(
+        resp: model_interface.UpdateUserModelResponse = self.hosts[
+            self.instance
+        ].client.UpdateUserModel(
             request=model_interface.UpdateUserModelRequest(
                 model=model,
                 update_mask=mask,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.model
 
     @grpc_handler
     def lookup_model(self, model_uid: str) -> model_interface.Model:
-        resp: model_interface.LookUpModelResponse = self.hosts[self.instance][
-            "client"
-        ].LookUpModel(
+        resp: model_interface.LookUpModelResponse = self.hosts[
+            self.instance
+        ].client.LookUpModel(
             request=model_interface.LookUpModelRequest(permalink=f"models/{model_uid}"),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.model
 
     @grpc_handler
     def get_model_card(self, model_name: str) -> model_interface.ModelCard:
-        resp: model_interface.GetUserModelCardResponse = self.hosts[self.instance][
-            "client"
-        ].GetUserModel(
+        resp: model_interface.GetUserModelCardResponse = self.hosts[
+            self.instance
+        ].client.GetUserModel(
             request=model_interface.GetUserModelCardRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.readme
 
@@ -297,26 +280,26 @@ class ModelClient(Client):
             model_interface.ListModelsResponse, model_interface.ListUserModelsResponse
         ]
         if not public:
-            resp = self.hosts[self.instance]["client"].ListUserModels(
+            resp = self.hosts[self.instance].client.ListUserModels(
                 request=model_interface.ListUserModelsRequest(parent=self.namespace),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
         else:
-            resp = self.hosts[self.instance]["client"].ListModels(
+            resp = self.hosts[self.instance].client.ListModels(
                 request=model_interface.ListModelsRequest(),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
 
         return resp.models, resp.next_page_token, resp.total_size
 
     @grpc_handler
     def get_operation(self, name: str) -> operations_pb2.Operation:
-        resp: model_interface.GetModelOperationResponse = self.hosts[self.instance][
-            "client"
-        ].GetModelOperation(
+        resp: model_interface.GetModelOperationResponse = self.hosts[
+            self.instance
+        ].client.GetModelOperation(
             request=model_interface.GetModelOperationRequest(
                 name=name,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.operation

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -1,8 +1,6 @@
 # pylint: disable=no-member,wrong-import-position
-import time
-from typing import Dict, Iterable, Tuple, Union
+from typing import Dict
 
-from google.longrunning import operations_pb2
 from google.protobuf import field_mask_pb2
 
 # common
@@ -12,7 +10,7 @@ import instill.protogen.model.model.v1alpha.model_definition_pb2 as model_defini
 # model
 import instill.protogen.model.model.v1alpha.model_pb2 as model_interface
 import instill.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
-from instill.clients.base import Client
+from instill.clients.base import Client, RequestFactory
 from instill.clients.constant import DEFAULT_INSTANCE
 from instill.clients.instance import InstillInstance
 from instill.configuration import global_config
@@ -64,38 +62,67 @@ class ModelClient(Client):
     def metadata(self, metadata: str):
         self._metadata = metadata
 
-    def liveness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: model_interface.LivenessResponse = self.hosts[
-            self.instance
-        ].client.Liveness(request=model_interface.LivenessRequest())
-        return resp.health_check_response.status
+    def liveness(self, async_enabled: bool = False) -> model_interface.LivenessResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.Liveness,
+                request=model_interface.LivenessRequest(),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
 
-    def readiness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: model_interface.ReadinessResponse = self.hosts[
-            self.instance
-        ].client.Readiness(request=model_interface.ReadinessRequest())
-        return resp.health_check_response.status
+        return RequestFactory(
+            method=self.hosts[self.instance].client.Liveness,
+            request=model_interface.LivenessRequest(),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
+
+    def readiness(
+        self, async_enabled: bool = False
+    ) -> model_interface.ReadinessResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.Readiness,
+                request=model_interface.ReadinessRequest(),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.Readiness,
+            request=model_interface.ReadinessRequest(),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
 
     def is_serving(self) -> bool:
         try:
             return (
-                self.readiness()
+                self.readiness().health_check_response.status
                 == healthcheck.HealthCheckResponse.SERVING_STATUS_SERVING
             )
         except Exception:
             return False
 
     @grpc_handler
-    def watch_model(self, model_name: str) -> model_interface.Model.State.ValueType:
-        resp: model_interface.WatchUserModelResponse = self.hosts[
-            self.instance
-        ].client.WatchUserModel(
+    def watch_model(
+        self,
+        model_name: str,
+        async_enabled: bool = False,
+    ) -> model_interface.WatchUserModelResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.WatchUserModel,
+                request=model_interface.WatchUserModelRequest(
+                    name=f"{self.namespace}/models/{model_name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.WatchUserModel,
             request=model_interface.WatchUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.state
+        ).send_sync()
 
     @grpc_handler
     def create_model_local(
@@ -103,7 +130,7 @@ class ModelClient(Client):
         model_name: str,
         model_description: str,
         model_path: str,
-    ) -> model_interface.Model:
+    ) -> model_interface.CreateUserModelBinaryFileUploadResponse:
         model = model_interface.Model()
         model.id = model_name
         model.description = model_description
@@ -114,25 +141,11 @@ class ModelClient(Client):
             req = model_interface.CreateUserModelBinaryFileUploadRequest(
                 parent=self.namespace, model=model, content=data
             )
-        create_resp: model_interface.CreateUserModelBinaryFileUploadResponse = (
-            self.hosts[self.instance].client.CreateUserModelBinaryFileUpload(
-                request_iterator=iter([req]),
-                metadata=self.hosts[self.instance].metadata,
-            )
-        )
-
-        while self.get_operation(name=create_resp.operation.name).done is not True:
-            time.sleep(1)
-
-        state = self.watch_model(model_name=model_name)
-        while state == 0:
-            time.sleep(1)
-            state = self.watch_model(model_name=model_name)
-
-        if state == 1:
-            return self.get_model(model_name=model_name)
-
-        raise SystemError("model creation failed")
+        return RequestFactory(
+            method=self.hosts[self.instance].client.CreateUserModelBinaryFileUpload,
+            request=req,
+            metadata=self.hosts[self.instance].metadata,
+        ).send_stream()
 
     @grpc_handler
     def create_model(
@@ -140,166 +153,296 @@ class ModelClient(Client):
         name: str,
         definition: str,
         configuration: dict,
-    ) -> model_interface.Model:
+        async_enabled: bool = False,
+    ) -> model_interface.CreateUserModelResponse:
         model = model_interface.Model()
         model.id = name
         model.model_definition = definition
         model.configuration.update(configuration)
-        create_resp: model_interface.CreateUserModelResponse = self.hosts[
-            self.instance
-        ].client.CreateUserModel(
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.CreateUserModel,
+                request=model_interface.CreateUserModelRequest(
+                    model=model, parent=self.namespace
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.CreateUserModel,
             request=model_interface.CreateUserModelRequest(
                 model=model, parent=self.namespace
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-
-        while self.get_operation(name=create_resp.operation.name).done is not True:
-            time.sleep(1)
-
-        # TODO: due to state update delay of controller
-        # TODO: should optimize this in model-backend
-        time.sleep(3)
-
-        state = self.watch_model(model_name=name)
-        while state == 0:
-            time.sleep(1)
-            state = self.watch_model(model_name=name)
-
-        if state == 1:
-            return self.get_model(model_name=name)
-
-        raise SystemError("model creation failed")
+        ).send_sync()
 
     @grpc_handler
-    def deploy_model(self, model_name: str) -> model_interface.Model.State:
-        self.hosts[self.instance].client.DeployUserModel(
+    def deploy_model(
+        self,
+        model_name: str,
+        async_enabled: bool = False,
+    ) -> model_interface.DeployUserModelResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.DeployUserModel,
+                request=model_interface.DeployUserModelRequest(
+                    name=f"{self.namespace}/models/{model_name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.DeployUserModel,
             request=model_interface.DeployUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-
-        state = self.watch_model(model_name=model_name)
-        while state not in (2, 3):
-            time.sleep(1)
-            state = self.watch_model(model_name=model_name)
-
-        return state
+        ).send_sync()
 
     @grpc_handler
-    def undeploy_model(self, model_name: str) -> model_interface.Model.State:
-        self.hosts[self.instance].client.UndeployUserModel(
+    def undeploy_model(
+        self,
+        model_name: str,
+        async_enabled: bool = False,
+    ) -> model_interface.UndeployUserModelResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.UndeployUserModel,
+                request=model_interface.UndeployUserModelRequest(
+                    name=f"{self.namespace}/models/{model_name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.UndeployUserModel,
             request=model_interface.UndeployUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-
-        state = self.watch_model(model_name=model_name)
-        while state not in (1, 3):
-            time.sleep(1)
-            state = self.watch_model(model_name=model_name)
-
-        return state
+        ).send_sync()
 
     @grpc_handler
-    def trigger_model(self, model_name: str, task_inputs: list) -> Iterable:
-        resp: model_interface.TriggerUserModelResponse = self.hosts[
-            self.instance
-        ].client.TriggerUserModel(
+    def trigger_model(
+        self,
+        model_name: str,
+        task_inputs: list,
+        async_enabled: bool = False,
+    ) -> model_interface.TriggerUserModelResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.TriggerUserModel,
+                request=model_interface.TriggerUserModelRequest(
+                    name=f"{self.namespace}/models/{model_name}",
+                    task_inputs=task_inputs,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.TriggerUserModel,
             request=model_interface.TriggerUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}", task_inputs=task_inputs
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.task_outputs
+        ).send_sync()
 
     @grpc_handler
-    def delete_model(self, model_name: str):
-        self.hosts[self.instance].client.DeleteUserModel(
+    def delete_model(
+        self,
+        model_name: str,
+        async_enabled: bool = False,
+    ) -> model_interface.DeleteUserModelResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.DeleteUserModel,
+                request=model_interface.DeleteUserModelRequest(
+                    name=f"{self.namespace}/models/{model_name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.DeleteUserModel,
             request=model_interface.DeleteUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
+        ).send_sync()
 
     @grpc_handler
-    def get_model(self, model_name: str) -> model_interface.Model:
-        resp: model_interface.GetUserModelResponse = self.hosts[
-            self.instance
-        ].client.GetUserModel(
+    def get_model(
+        self,
+        model_name: str,
+        async_enabled: bool = False,
+    ) -> model_interface.GetUserModelResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.GetUserModel,
+                request=model_interface.GetUserModelRequest(
+                    name=f"{self.namespace}/models/{model_name}",
+                    view=model_definition_interface.VIEW_FULL,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.GetUserModel,
             request=model_interface.GetUserModelRequest(
                 name=f"{self.namespace}/models/{model_name}",
                 view=model_definition_interface.VIEW_FULL,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.model
+        ).send_sync()
 
     @grpc_handler
     def update_model(
-        self, model: model_interface.Model, mask: field_mask_pb2.FieldMask
-    ) -> model_interface.Model:
-        resp: model_interface.UpdateUserModelResponse = self.hosts[
-            self.instance
-        ].client.UpdateUserModel(
+        self,
+        model: model_interface.Model,
+        mask: field_mask_pb2.FieldMask,
+        async_enabled: bool = False,
+    ) -> model_interface.UpdateUserModelResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.UpdateUserModel,
+                request=model_interface.UpdateUserModelRequest(
+                    model=model,
+                    update_mask=mask,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.UpdateUserModel,
             request=model_interface.UpdateUserModelRequest(
                 model=model,
                 update_mask=mask,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.model
+        ).send_sync()
 
     @grpc_handler
-    def lookup_model(self, model_uid: str) -> model_interface.Model:
-        resp: model_interface.LookUpModelResponse = self.hosts[
-            self.instance
-        ].client.LookUpModel(
+    def lookup_model(
+        self,
+        model_uid: str,
+        async_enabled: bool = False,
+    ) -> model_interface.LookUpModelResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.LookUpModel,
+                request=model_interface.LookUpModelRequest(
+                    permalink=f"models/{model_uid}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.LookUpModel,
             request=model_interface.LookUpModelRequest(permalink=f"models/{model_uid}"),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.model
+        ).send_sync()
 
     @grpc_handler
-    def get_model_card(self, model_name: str) -> model_interface.ModelCard:
-        resp: model_interface.GetUserModelCardResponse = self.hosts[
-            self.instance
-        ].client.GetUserModel(
+    def get_model_card(
+        self,
+        model_name: str,
+        async_enabled: bool = False,
+    ) -> model_interface.GetUserModelCardResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.GetUserModelCard,
+                request=model_interface.GetUserModelCardRequest(
+                    name=f"{self.namespace}/models/{model_name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.GetUserModelCard,
             request=model_interface.GetUserModelCardRequest(
                 name=f"{self.namespace}/models/{model_name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.readme
+        ).send_sync()
 
     @grpc_handler
-    def list_models(self, public=False) -> Tuple[Iterable, str, int]:
-        resp: Union[
-            model_interface.ListModelsResponse, model_interface.ListUserModelsResponse
-        ]
-        if not public:
-            resp = self.hosts[self.instance].client.ListUserModels(
-                request=model_interface.ListUserModelsRequest(parent=self.namespace),
+    def list_models(
+        self,
+        next_page_token: str = "",
+        total_size: int = 100,
+        show_deleted: bool = False,
+        public=False,
+        async_enabled: bool = False,
+    ) -> model_interface.ListUserModelsResponse:
+        if async_enabled:
+            if public:
+                method = self.hosts[self.instance].async_client.ListModels
+                return RequestFactory(
+                    method=method,
+                    request=model_interface.ListModelsRequest(
+                        page_size=total_size,
+                        page_token=next_page_token,
+                        show_deleted=show_deleted,
+                        view=model_definition_interface.VIEW_FULL,
+                    ),
+                    metadata=self.hosts[self.instance].metadata,
+                ).send_async()
+            method = self.hosts[self.instance].async_client.ListUserModels
+            return RequestFactory(
+                method=method,
+                request=model_interface.ListUserModelsRequest(
+                    parent=self.namespace,
+                    page_size=total_size,
+                    page_token=next_page_token,
+                    show_deleted=show_deleted,
+                    view=model_definition_interface.VIEW_FULL,
+                ),
                 metadata=self.hosts[self.instance].metadata,
-            )
-        else:
-            resp = self.hosts[self.instance].client.ListModels(
-                request=model_interface.ListModelsRequest(),
+            ).send_async()
+        if public:
+            method = self.hosts[self.instance].client.ListModels
+            return RequestFactory(
+                method=method,
+                request=model_interface.ListModelsRequest(
+                    page_size=total_size,
+                    page_token=next_page_token,
+                    show_deleted=show_deleted,
+                    view=model_definition_interface.VIEW_FULL,
+                ),
                 metadata=self.hosts[self.instance].metadata,
-            )
-
-        return resp.models, resp.next_page_token, resp.total_size
+            ).send_sync()
+        method = self.hosts[self.instance].client.ListUserModels
+        return RequestFactory(
+            method=method,
+            request=model_interface.ListUserModelsRequest(
+                parent=self.namespace,
+                page_size=total_size,
+                page_token=next_page_token,
+                show_deleted=show_deleted,
+                view=model_definition_interface.VIEW_FULL,
+            ),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
 
     @grpc_handler
-    def get_operation(self, name: str) -> operations_pb2.Operation:
-        resp: model_interface.GetModelOperationResponse = self.hosts[
-            self.instance
-        ].client.GetModelOperation(
+    def get_operation(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> model_interface.GetModelOperationResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.GetModelOperation,
+                request=model_interface.GetModelOperationRequest(
+                    name=name,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.GetModelOperation,
             request=model_interface.GetModelOperationRequest(
                 name=name,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.operation
+        ).send_sync()

--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -20,7 +20,7 @@ from instill.utils.error_handler import grpc_handler
 
 
 class ModelClient(Client):
-    def __init__(self, namespace: str, asyncio: bool) -> None:
+    def __init__(self, namespace: str, async_enabled: bool) -> None:
         self.hosts: Dict[str, InstillInstance] = {}
         self.namespace: str = namespace
         if DEFAULT_INSTANCE in global_config.hosts:
@@ -37,7 +37,7 @@ class ModelClient(Client):
                     url=config.url,
                     token=config.token,
                     secure=config.secure,
-                    asyncio=asyncio,
+                    async_enabled=async_enabled,
                 )
 
     @property

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -1,7 +1,6 @@
 # pylint: disable=no-member,wrong-import-position
-from typing import Dict, Iterable, Tuple, Union
+from typing import Dict, Union
 
-from google.longrunning import operations_pb2
 from google.protobuf import field_mask_pb2
 
 # common
@@ -12,7 +11,7 @@ import instill.protogen.vdp.pipeline.v1alpha.connector_pb2 as connector_interfac
 import instill.protogen.vdp.pipeline.v1alpha.operator_definition_pb2 as operator_interface
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_pb2 as pipeline_interface
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
-from instill.clients.base import Client
+from instill.clients.base import Client, RequestFactory
 from instill.clients.constant import DEFAULT_INSTANCE
 from instill.clients.instance import InstillInstance
 from instill.configuration import global_config
@@ -66,22 +65,38 @@ class PipelineClient(Client):
     def metadata(self, metadata: str):
         self._metadata = metadata
 
-    def liveness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: pipeline_interface.LivenessResponse = self.hosts[
-            self.instance
-        ].client.Liveness(request=pipeline_interface.LivenessRequest())
-        return resp.health_check_response.status
+    def liveness(self, async_enabled: bool = False) -> healthcheck.HealthCheckResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.Liveness,
+                request=pipeline_interface.LivenessRequest(),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
 
-    def readiness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: pipeline_interface.ReadinessResponse = self.hosts[
-            self.instance
-        ].client.Readiness(request=pipeline_interface.ReadinessRequest())
-        return resp.health_check_response.status
+        return RequestFactory(
+            method=self.hosts[self.instance].client.Liveness,
+            request=pipeline_interface.LivenessRequest(),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
+
+    def readiness(self, async_enabled: bool = False) -> healthcheck.HealthCheckResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.Readiness,
+                request=pipeline_interface.ReadinessRequest(),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.Readiness,
+            request=pipeline_interface.ReadinessRequest(),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
 
     def is_serving(self) -> bool:
         try:
             return (
-                self.readiness()
+                self.readiness().status
                 == healthcheck.HealthCheckResponse.SERVING_STATUS_SERVING
             )
         except Exception:
@@ -90,174 +105,278 @@ class PipelineClient(Client):
     @grpc_handler
     def list_operator_definitions(
         self,
-        filer_str: str = "",
+        filter_str: str = "",
         next_page_token: str = "",
         total_size: int = 100,
-    ) -> Tuple[Iterable, str, int]:
-        resp: operator_interface.ListOperatorDefinitionsResponse = self.hosts[
-            self.instance
-        ].client.ListUserPipelines(
+        async_enabled: bool = False,
+    ) -> operator_interface.ListOperatorDefinitionsResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.ListOperatorDefinitions,
+                request=operator_interface.ListOperatorDefinitionsRequest(
+                    filter=filter_str,
+                    page_size=total_size,
+                    page_token=next_page_token,
+                    view=operator_interface.ListOperatorDefinitionsRequest.VIEW_FULL,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.ListOperatorDefinitions,
             request=operator_interface.ListOperatorDefinitionsRequest(
-                filter=filer_str,
+                filter=filter_str,
                 page_size=total_size,
                 page_token=next_page_token,
                 view=operator_interface.ListOperatorDefinitionsRequest.VIEW_FULL,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-
-        return resp.operator_definitions, resp.next_page_token, resp.total_size
+        ).send_sync()
 
     @grpc_handler
     def get_operator_definition(
-        self, name: str
-    ) -> operator_interface.OperatorDefinition:
-        resp: operator_interface.GetOperatorDefinitionResponse = self.hosts[
-            self.instance
-        ].client.GetOperatorDefinition(
+        self, name: str, async_enabled: bool = False
+    ) -> operator_interface.GetOperatorDefinitionResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.GetOperatorDefinition,
+                request=operator_interface.GetOperatorDefinitionRequest(
+                    name=f"operator-definitions//{name}",
+                    view=operator_interface.GetOperatorDefinitionRequest.VIEW_FULL,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.GetOperatorDefinition,
             request=operator_interface.GetOperatorDefinitionRequest(
                 name=f"operator-definitions//{name}",
                 view=operator_interface.GetOperatorDefinitionRequest.VIEW_FULL,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.operator_definition
+        ).send_sync()
 
     @grpc_handler
     def create_pipeline(
         self,
         name: str,
         recipe: pipeline_interface.Recipe,
-    ) -> pipeline_interface.Pipeline:
+        async_enabled: bool = False,
+    ) -> pipeline_interface.CreateUserPipelineResponse:
         pipeline = pipeline_interface.Pipeline(
             id=name,
             recipe=recipe,
         )
-        resp: pipeline_interface.CreateUserPipelineResponse = self.hosts[
-            self.instance
-        ].client.CreateUserPipeline(
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.CreateuserPipeline,
+                request=pipeline_interface.CreateUserPipelineRequest(
+                    pipeline=pipeline, parent=self.namespace
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.CreateUserPipeline,
             request=pipeline_interface.CreateUserPipelineRequest(
                 pipeline=pipeline, parent=self.namespace
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.pipeline
+        ).send_sync()
 
     @grpc_handler
-    def get_pipeline(self, name: str) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.GetUserPipelineResponse = self.hosts[
-            self.instance
-        ].client.GetUserPipeline(
+    def get_pipeline(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.GetUserPipelineResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.GetUserPipeline,
+                request=pipeline_interface.GetUserPipelineRequest(
+                    name=f"{self.namespace}/pipelines/{name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.CreateUserPipeline,
             request=pipeline_interface.GetUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.pipeline
+        ).send_sync()
 
     @grpc_handler
-    def lookup_pipeline(self, pipeline_uid: str) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.LookUpPipelineResponse = self.hosts[
-            self.instance
-        ].client.LookUpPipeline(
+    def lookup_pipeline(
+        self,
+        pipeline_uid: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.LookUpPipelineResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.LookUpPipeline,
+                request=pipeline_interface.LookUpPipelineRequest(
+                    permalink=f"pipelines/{pipeline_uid}",
+                    view=pipeline_interface.LookUpPipelineRequest.VIEW_FULL,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.LookUpPipeline,
             request=pipeline_interface.LookUpPipelineRequest(
                 permalink=f"pipelines/{pipeline_uid}",
                 view=pipeline_interface.LookUpPipelineRequest.VIEW_FULL,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.pipeline
+        ).send_sync()
 
     @grpc_handler
-    def rename_pipeline(self, name: str, new_name: str) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.RenameUserPipelineResponse = self.hosts[
-            self.instance
-        ].client.RenameUserPipeline(
+    def rename_pipeline(
+        self,
+        name: str,
+        new_name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.RenameUserPipelineResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.RenameUserPipeline,
+                request=pipeline_interface.RenameUserPipelineRequest(
+                    name=f"{self.namespace}/pipelines/{name}",
+                    new_pipeline_id=new_name,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.RenameUserPipeline,
             request=pipeline_interface.RenameUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}",
                 new_pipeline_id=new_name,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.pipeline
+        ).send_sync()
 
     @grpc_handler
     def update_pipeline(
-        self, pipeline: pipeline_interface.Pipeline, mask: field_mask_pb2.FieldMask
-    ) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.UpdateUserPipelineResponse = self.hosts[
-            self.instance
-        ].client.UpdateUserPipeline(
+        self,
+        pipeline: pipeline_interface.Pipeline,
+        mask: field_mask_pb2.FieldMask,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.UpdateUserPipelineResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.UpdateUserPipeline,
+                request=pipeline_interface.UpdateUserPipelineRequest(
+                    pipeline=pipeline,
+                    update_mask=mask,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.UpdateUserPipeline,
             request=pipeline_interface.UpdateUserPipelineRequest(
                 pipeline=pipeline,
                 update_mask=mask,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.pipeline
+        ).send_sync()
 
     @grpc_handler
-    def validate_pipeline(self, name: str) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.ValidateUserPipelineResponse = self.hosts[
-            self.instance
-        ].client.ValidateUserPipeline(
+    def validate_pipeline(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.ValidateUserPipelineResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.ValidateUserPipeline,
+                request=pipeline_interface.ValidateUserPipelineRequest(
+                    name=f"{self.namespace}/pipelines/{name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.ValidateUserPipeline,
             request=pipeline_interface.ValidateUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.pipeline
+        ).send_sync()
 
     @grpc_handler
     def trigger_pipeline(
-        self, name: str, inputs: list
-    ) -> Tuple[Iterable, pipeline_interface.TriggerMetadata]:
-        resp: pipeline_interface.TriggerUserPipelineResponse = self.hosts[
-            self.instance
-        ].client.TriggerUserPipeline(
-            request=pipeline_interface.TriggerUserPipelineRequest(
-                name=f"{self.namespace}/pipelines/{name}", inputs=inputs
-            ),
-            metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.outputs, resp.metadata
+        self,
+        name: str,
+        inputs: list,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.TriggerUserPipelineResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.TriggerUserPipeline,
+                request=pipeline_interface.TriggerUserPipelineRequest(
+                    name=f"{self.namespace}/pipelines/{name}", inputs=inputs
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
 
-    @grpc_handler
-    async def trigger_asyncio_pipeline(
-        self, name: str, inputs: list
-    ) -> Tuple[Iterable, pipeline_interface.TriggerMetadata]:
-        resp: pipeline_interface.TriggerUserPipelineResponse = await self.hosts[
-            self.instance
-        ].async_client.TriggerUserPipeline(
+        return RequestFactory(
+            method=self.hosts[self.instance].client.TriggerUserPipeline,
             request=pipeline_interface.TriggerUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.outputs, resp.metadata
+        ).send_sync()
 
     @grpc_handler
     def trigger_async_pipeline(
-        self, name: str, inputs: list
-    ) -> operations_pb2.Operation:
-        resp: pipeline_interface.TriggerAsyncUserPipelineResponse = self.hosts[
-            self.instance
-        ].client.TriggerAsyncUserPipeline(
+        self,
+        name: str,
+        inputs: list,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.TriggerAsyncUserPipelineResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.TriggerAsyncUserPipeline,
+                request=pipeline_interface.TriggerAsyncUserPipelineRequest(
+                    name=f"{self.namespace}/pipelines/{name}", inputs=inputs
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.TriggerAsyncUserPipeline,
             request=pipeline_interface.TriggerAsyncUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.operation
+        ).send_sync()
 
     @grpc_handler
-    def delete_pipeline(self, name: str):
-        self.hosts[self.instance].client.DeleteUserPipeline(
+    def delete_pipeline(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.DeleteUserPipelineReleaseResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.DeleteUserPipeline,
+                request=pipeline_interface.DeleteUserPipelineRequest(
+                    name=f"{self.namespace}/pipelines/{name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.DeleteUserPipeline,
             request=pipeline_interface.DeleteUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
+        ).send_sync()
 
     @grpc_handler
     def list_pipelines(
@@ -267,13 +386,18 @@ class PipelineClient(Client):
         total_size: int = 100,
         show_deleted: bool = False,
         public=False,
-    ) -> Tuple[Iterable, str, int]:
-        resp: Union[
-            pipeline_interface.ListPipelinesResponse,
-            pipeline_interface.ListUserPipelinesResponse,
-        ]
-        if not public:
-            resp = self.hosts[self.instance].client.ListUserPipelines(
+        async_enabled: bool = False,
+    ) -> Union[
+        pipeline_interface.ListPipelinesResponse,
+        pipeline_interface.ListUserPipelinesResponse,
+    ]:
+        if async_enabled:
+            if public:
+                method = self.hosts[self.instance].async_client.ListPipelines
+            else:
+                method = self.hosts[self.instance].async_client.ListUserPipelines
+            return RequestFactory(
+                method=method,
                 request=pipeline_interface.ListUserPipelinesRequest(
                     parent=self.namespace,
                     filter=filer_str,
@@ -283,38 +407,53 @@ class PipelineClient(Client):
                     view=pipeline_interface.ListUserPipelinesRequest.VIEW_FULL,
                 ),
                 metadata=self.hosts[self.instance].metadata,
-            )
+            ).send_async()
+        if public:
+            method = self.hosts[self.instance].client.ListPipelines
         else:
-            resp = self.hosts[self.instance].client.ListPipelines(
-                request=pipeline_interface.ListPipelinesRequest(
-                    filter=filer_str,
-                    page_size=total_size,
-                    page_token=next_page_token,
-                    show_deleted=show_deleted,
-                    view=pipeline_interface.ListPipelinesRequest.VIEW_FULL,
-                ),
-                metadata=self.hosts[self.instance].metadata,
-            )
-
-        return resp.pipelines, resp.next_page_token, resp.total_size
+            method = self.hosts[self.instance].client.ListUserPipelines
+        return RequestFactory(
+            method=method,
+            request=pipeline_interface.ListUserPipelinesRequest(
+                parent=self.namespace,
+                filter=filer_str,
+                page_size=total_size,
+                page_token=next_page_token,
+                show_deleted=show_deleted,
+                view=pipeline_interface.ListUserPipelinesRequest.VIEW_FULL,
+            ),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
 
     @grpc_handler
-    def get_operation(self, name: str) -> operations_pb2.Operation:
-        resp: pipeline_interface.GetOperationResponse = self.hosts[
-            self.instance
-        ].client.GetOperation(
+    def get_operation(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.GetOperationResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.GetOperation,
+                request=pipeline_interface.GetOperationRequest(
+                    name=name,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.GetOperation,
             request=pipeline_interface.GetOperationRequest(
                 name=name,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.operation
+        ).send_sync()
 
     @grpc_handler
     def create_pipeline_release(
         self,
         version: str,
-    ) -> pipeline_interface.PipelineRelease:
+        async_enabled: bool = False,
+    ) -> pipeline_interface.CreateUserPipelineReleaseResponse:
         """Create a release version of a pipeline
 
         Args:
@@ -326,18 +465,29 @@ class PipelineClient(Client):
         pipeline_release = pipeline_interface.PipelineRelease(
             id=version,
         )
-        resp: pipeline_interface.CreateUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.CreateUserPipelineRelease(
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.CreateUserPipelineRelease,
+                request=pipeline_interface.CreateUserPipelineReleaseRequest(
+                    release=pipeline_release, parent=self.namespace
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.CreateUserPipelineRelease,
             request=pipeline_interface.CreateUserPipelineReleaseRequest(
                 release=pipeline_release, parent=self.namespace
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.release
+        ).send_sync()
 
     @grpc_handler
-    def get_pipeline_release(self, name: str) -> pipeline_interface.PipelineRelease:
+    def get_pipeline_release(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.GetUserPipelineReleaseResponse:
         """Get a released pipeline
 
         Args:
@@ -346,21 +496,32 @@ class PipelineClient(Client):
         Returns:
             pipeline_interface.Pipeline: Released pipeline
         """
-        resp: pipeline_interface.GetUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.GetUserPipelineRelease(
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.GetUserPipelineRelease,
+                request=pipeline_interface.GetUserPipelineReleaseRequest(
+                    name=f"{self.namespace}/pipelines/{name}",
+                    view=pipeline_interface.GetUserPipelineReleaseRequest.VIEW_FULL,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.GetUserPipelineRelease,
             request=pipeline_interface.GetUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
                 view=pipeline_interface.GetUserPipelineReleaseRequest.VIEW_FULL,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.release
+        ).send_sync()
 
     @grpc_handler
     def rename_pipeline_release(
-        self, name: str, new_version: str
-    ) -> pipeline_interface.PipelineRelease:
+        self,
+        name: str,
+        new_version: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.RenameUserPipelineReleaseResponse:
         """Rename a released pipeline
 
         Args:
@@ -370,33 +531,50 @@ class PipelineClient(Client):
         Returns:
             pipeline_interface.PipelineRelease: released pipeline
         """
-        resp: pipeline_interface.RenameUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.RenameUserPipelineRelease(
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.RenameUserPipelineRelease,
+                request=pipeline_interface.RenameUserPipelineReleaseRequest(
+                    name=f"{self.namespace}/pipelines/{name}",
+                    new_pipeline_release_id=new_version,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.RenameUserPipelineRelease,
             request=pipeline_interface.RenameUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
                 new_pipeline_release_id=new_version,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.release
+        ).send_sync()
 
     @grpc_handler
     def update_pipeline_release(
         self,
         pipeline_release: pipeline_interface.PipelineRelease,
         mask: field_mask_pb2.FieldMask,
-    ) -> pipeline_interface.PipelineRelease:
-        resp: pipeline_interface.UpdateUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.UpdateUserPipelineRelease(
+        async_enabled: bool = False,
+    ) -> pipeline_interface.UpdateUserPipelineReleaseResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.UpdateUserPipelineRelease,
+                request=pipeline_interface.UpdateUserPipelineReleaseRequest(
+                    release=pipeline_release,
+                    update_mask=mask,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.UpdateUserPipelineRelease,
             request=pipeline_interface.UpdateUserPipelineReleaseRequest(
                 release=pipeline_release,
                 update_mask=mask,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.release
+        ).send_sync()
 
     @grpc_handler
     def list_pipeline_releases(
@@ -405,10 +583,24 @@ class PipelineClient(Client):
         next_page_token: str = "",
         total_size: int = 100,
         show_deleted: bool = False,
-    ) -> Tuple[Iterable, str, int]:
-        resp: pipeline_interface.ListUserPipelineReleasesResponse = self.hosts[
-            self.instance
-        ].client.ListUserPipelineReleases(
+        async_enabled: bool = False,
+    ) -> pipeline_interface.ListUserPipelineReleasesResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.ListUserPipelineReleases,
+                request=pipeline_interface.ListUserPipelineReleasesRequest(
+                    parent=self.namespace,
+                    filter=filer_str,
+                    page_size=total_size,
+                    page_token=next_page_token,
+                    show_deleted=show_deleted,
+                    view=pipeline_interface.ListUserPipelineReleasesRequest.VIEW_FULL,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.ListUserPipelineReleases,
             request=pipeline_interface.ListUserPipelineReleasesRequest(
                 parent=self.namespace,
                 filter=filer_str,
@@ -418,84 +610,153 @@ class PipelineClient(Client):
                 view=pipeline_interface.ListUserPipelineReleasesRequest.VIEW_FULL,
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-
-        return resp.releases, resp.next_page_token, resp.total_size
+        ).send_sync()
 
     @grpc_handler
-    def delete_pipeline_release(self, name: str):
-        self.hosts[self.instance].client.DeleteUserPipelineRelease(
+    def delete_pipeline_release(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.DeleteUserPipelineReleaseResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.DeleteUserPipelineRelease,
+                request=pipeline_interface.DeleteUserPipelineReleaseRequest(
+                    name=f"{self.namespace}/pipelines/{name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.DeleteUserPipelineRelease,
             request=pipeline_interface.DeleteUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
+        ).send_sync()
 
     @grpc_handler
     def set_default_pipeline_release(
-        self, name: str
-    ) -> pipeline_interface.PipelineRelease:
-        resp: pipeline_interface.SetDefaultUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.SetDefaultUserPipelineRelease(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.SetDefaultUserPipelineReleaseResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[
+                    self.instance
+                ].async_client.SetDefaultUserPipelineRelease,
+                request=pipeline_interface.SetDefaultUserPipelineReleaseRequest(
+                    name=f"{self.namespace}/pipelines/{name}",
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.SetDefaultUserPipelineRelease,
             request=pipeline_interface.SetDefaultUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.release
+        ).send_sync()
 
     @grpc_handler
-    def restore_pipeline_release(self, name: str) -> pipeline_interface.PipelineRelease:
-        resp: pipeline_interface.RestoreUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.RestoreUserPipelineRelease(
+    def restore_pipeline_release(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.RestoreUserPipelineReleaseResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[
+                    self.instance
+                ].async_client.RestoreUserPipelineRelease,
+                request=pipeline_interface.RestoreUserPipelineReleaseRequest(
+                    name=f"{self.namespace}/pipelines/{name}",
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.RestoreUserPipelineRelease,
             request=pipeline_interface.RestoreUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.release
+        ).send_sync()
 
     @grpc_handler
-    def watch_pipeline_release(self, name: str) -> pipeline_interface.State.ValueType:
-        resp: pipeline_interface.WatchUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.WatchUserPipelineRelease(
+    def watch_pipeline_release(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.WatchUserPipelineReleaseResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.WatchUserPipelineRelease,
+                request=pipeline_interface.WatchUserPipelineReleaseRequest(
+                    name=f"{self.namespace}/pipelines/{name}",
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.WatchUserPipelineRelease,
             request=pipeline_interface.WatchUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.state
+        ).send_sync()
 
     @grpc_handler
     def trigger_pipeline_release(
-        self, name: str, inputs: list
-    ) -> Tuple[Iterable, pipeline_interface.TriggerMetadata]:
-        resp: pipeline_interface.TriggerUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.TriggerUserPipelineReleas(
+        self,
+        name: str,
+        inputs: list,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.TriggerUserPipelineReleaseResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.TriggerUserPipelineReleas,
+                request=pipeline_interface.TriggerUserPipelineReleaseRequest(
+                    name=f"{self.namespace}/pipelines/{name}", inputs=inputs
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.TriggerUserPipelineReleas,
             request=pipeline_interface.TriggerUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.outputs, resp.metadata
+        ).send_sync()
 
     @grpc_handler
     def trigger_async_pipeline_release(
-        self, name: str, inputs: list
-    ) -> operations_pb2.Operation:
-        resp: pipeline_interface.TriggerAsyncUserPipelineReleaseResponse = self.hosts[
-            self.instance
-        ].client.TriggerAsyncUserPipelineRelease(
+        self,
+        name: str,
+        inputs: list,
+        async_enabled: bool = False,
+    ) -> pipeline_interface.TriggerAsyncUserPipelineReleaseResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[
+                    self.instance
+                ].async_client.TriggerAsyncUserPipelineRelease,
+                request=pipeline_interface.TriggerAsyncUserPipelineReleaseRequest(
+                    name=f"{self.namespace}/pipelines/{name}", inputs=inputs
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.TriggerAsyncUserPipelineRelease,
             request=pipeline_interface.TriggerAsyncUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-        return resp.operation
+        ).send_sync()
 
     @grpc_handler
     def create_connector(
@@ -503,95 +764,187 @@ class PipelineClient(Client):
         name: str,
         definition: str,
         configuration: dict,
-    ) -> connector_interface.Connector:
+        async_enabled: bool = False,
+    ) -> connector_interface.CreateUserConnectorResponse:
         connector = connector_interface.Connector()
         connector.id = name
         connector.connector_definition_name = definition
         connector.configuration.update(configuration)
-        resp = self.hosts[self.instance].client.CreateUserConnector(
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.CreateUserConnector,
+                request=connector_interface.CreateUserConnectorRequest(
+                    connector=connector, parent=self.namespace
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.CreateUserConnector,
             request=connector_interface.CreateUserConnectorRequest(
                 connector=connector, parent=self.namespace
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
-
-        return resp.connector
+        ).send_sync()
 
     @grpc_handler
-    def get_connector(self, name: str) -> connector_interface.Connector:
-        return (
-            self.hosts[self.instance]
-            .client.GetUserConnector(
+    def get_connector(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> connector_interface.GetUserConnectorResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.GetUserConnector,
                 request=connector_interface.GetUserConnectorRequest(
                     name=f"{self.namespace}/connectors/{name}",
                     view=connector_interface.GetUserConnectorRequest.VIEW_FULL,
                 ),
                 metadata=self.hosts[self.instance].metadata,
-            )
-            .connector
-        )
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.GetUserConnector,
+            request=connector_interface.GetUserConnectorRequest(
+                name=f"{self.namespace}/connectors/{name}",
+                view=connector_interface.GetUserConnectorRequest.VIEW_FULL,
+            ),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
 
     @grpc_handler
-    def test_connector(self, name: str) -> connector_interface.Connector.State:
-        return (
-            self.hosts[self.instance]
-            .client.TestUserConnector(
+    def test_connector(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> connector_interface.TestUserConnectorResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.TestUserConnector,
                 request=connector_interface.TestUserConnectorRequest(
                     name=f"{self.namespace}/connectors/{name}"
                 ),
                 metadata=self.hosts[self.instance].metadata,
-            )
-            .state
-        )
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.TestUserConnector,
+            request=connector_interface.TestUserConnectorRequest(
+                name=f"{self.namespace}/connectors/{name}"
+            ),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
 
     @grpc_handler
-    def execute_connector(self, name: str, inputs: list) -> list:
-        return (
-            self.hosts[self.instance]
-            .client.ExecuteUserConnector(
+    def execute_connector(
+        self,
+        name: str,
+        inputs: list,
+        async_enabled: bool = False,
+    ) -> connector_interface.ExecuteUserConnectorResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.ExecuteUserConnector,
                 request=connector_interface.ExecuteUserConnectorRequest(
                     name=f"{self.namespace}/connectors/{name}", inputs=inputs
                 ),
                 metadata=self.hosts[self.instance].metadata,
-            )
-            .outputs
-        )
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.ExecuteUserConnector,
+            request=connector_interface.ExecuteUserConnectorRequest(
+                name=f"{self.namespace}/connectors/{name}", inputs=inputs
+            ),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
 
     @grpc_handler
-    def watch_connector(self, name: str) -> connector_interface.Connector.State:
-        return (
-            self.hosts[self.instance]
-            .client.WatchUserConnector(
+    def watch_connector(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> connector_interface.WatchUserConnectorResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.WatchUserConnector,
                 request=connector_interface.WatchUserConnectorRequest(
                     name=f"{self.namespace}/connectors/{name}"
                 ),
                 metadata=self.hosts[self.instance].metadata,
-            )
-            .state
-        )
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.WatchUserConnector,
+            request=connector_interface.WatchUserConnectorRequest(
+                name=f"{self.namespace}/connectors/{name}"
+            ),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()
 
     @grpc_handler
-    def delete_connector(self, name: str):
-        self.hosts[self.instance].client.DeleteUserConnector(
+    def delete_connector(
+        self,
+        name: str,
+        async_enabled: bool = False,
+    ) -> connector_interface.DeleteUserConnectorResponse:
+        if async_enabled:
+            return RequestFactory(
+                method=self.hosts[self.instance].async_client.DeleteUserConnector,
+                request=connector_interface.DeleteUserConnectorRequest(
+                    name=f"{self.namespace}/connectors/{name}"
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_async()
+
+        return RequestFactory(
+            method=self.hosts[self.instance].client.DeleteUserConnector,
             request=connector_interface.DeleteUserConnectorRequest(
                 name=f"{self.namespace}/connectors/{name}"
             ),
             metadata=self.hosts[self.instance].metadata,
-        )
+        ).send_sync()
 
     @grpc_handler
-    def list_connectors(self, public=False) -> Tuple[list, str, int]:
-        if not public:
-            resp = self.hosts[self.instance].client.ListUserConnectors(
+    def list_connectors(
+        self,
+        filer_str: str = "",
+        next_page_token: str = "",
+        total_size: int = 100,
+        show_deleted: bool = False,
+        public=False,
+        async_enabled: bool = False,
+    ) -> connector_interface.ListUserConnectorsResponse:
+        if async_enabled:
+            if public:
+                method = self.hosts[self.instance].async_client.ListConnectors
+            else:
+                method = self.hosts[self.instance].async_client.ListUserConnectors
+            return RequestFactory(
+                method=method,
                 request=connector_interface.ListUserConnectorsRequest(
-                    parent=self.namespace
+                    parent=self.namespace,
+                    filter=filer_str,
+                    page_size=total_size,
+                    page_token=next_page_token,
+                    show_deleted=show_deleted,
+                    view=connector_interface.ListUserConnectorsRequest.VIEW_FULL,
                 ),
                 metadata=self.hosts[self.instance].metadata,
-            )
+            ).send_async()
+        if public:
+            method = self.hosts[self.instance].client.ListConnectors
         else:
-            resp = self.hosts[self.instance].client.ListConnectors(
-                request=connector_interface.ListConnectorsRequest(),
-                metadata=(self.hosts[self.instance].metadata,),
-            )
-
-        return resp.connectors, resp.next_page_token, resp.total_size
+            method = self.hosts[self.instance].client.ListUserConnectors
+        return RequestFactory(
+            method=method,
+            request=connector_interface.ListUserConnectorsRequest(
+                parent=self.namespace,
+                filter=filer_str,
+                page_size=total_size,
+                page_token=next_page_token,
+                show_deleted=show_deleted,
+                view=connector_interface.ListUserConnectorsRequest.VIEW_FULL,
+            ),
+            metadata=self.hosts[self.instance].metadata,
+        ).send_sync()

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -1,20 +1,20 @@
 # pylint: disable=no-member,wrong-import-position
-from typing import Iterable, Tuple, Union, Dict
+from typing import Dict, Iterable, Tuple, Union
 
 from google.longrunning import operations_pb2
 from google.protobuf import field_mask_pb2
+
+# common
+import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 
 # pipeline
 import instill.protogen.vdp.pipeline.v1alpha.connector_pb2 as connector_interface
 import instill.protogen.vdp.pipeline.v1alpha.operator_definition_pb2 as operator_interface
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_pb2 as pipeline_interface
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
-
-# common
-import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
+from instill.clients.base import Client
 from instill.clients.constant import DEFAULT_INSTANCE
 from instill.clients.instance import InstillInstance
-from instill.clients.base import Client
 from instill.configuration import global_config
 from instill.utils.error_handler import grpc_handler
 

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -22,7 +22,7 @@ from instill.utils.error_handler import grpc_handler
 
 
 class PipelineClient(Client):
-    def __init__(self, namespace: str) -> None:
+    def __init__(self, namespace: str, asyncio: bool) -> None:
         self.hosts: Dict[str, InstillInstance] = {}
         self.namespace: str = namespace
         if DEFAULT_INSTANCE in global_config.hosts:
@@ -35,10 +35,11 @@ class PipelineClient(Client):
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():
                 self.hosts[instance] = InstillInstance(
-                    config.url,
-                    config.token,
-                    config.secure,
                     pipeline_service.PipelinePublicServiceStub,
+                    url=config.url,
+                    token=config.token,
+                    secure=config.secure,
+                    asyncio=asyncio,
                 )
 
     @property

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -1,21 +1,19 @@
 # pylint: disable=no-member,wrong-import-position
-from collections import defaultdict
-from typing import Iterable, Tuple, Union
+from typing import Iterable, Tuple, Union, Dict
 
-import grpc
 from google.longrunning import operations_pb2
 from google.protobuf import field_mask_pb2
-
-import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
 
 # pipeline
 import instill.protogen.vdp.pipeline.v1alpha.connector_pb2 as connector_interface
 import instill.protogen.vdp.pipeline.v1alpha.operator_definition_pb2 as operator_interface
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_pb2 as pipeline_interface
 import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
-from instill.clients import constant
 
 # common
+import instill.protogen.common.healthcheck.v1alpha.healthcheck_pb2 as healthcheck
+from instill.clients.constant import DEFAULT_INSTANCE
+from instill.clients.instance import InstillInstance
 from instill.clients.base import Client
 from instill.configuration import global_config
 from instill.utils.error_handler import grpc_handler
@@ -25,10 +23,10 @@ from instill.utils.error_handler import grpc_handler
 
 class PipelineClient(Client):
     def __init__(self, namespace: str) -> None:
-        self.hosts: defaultdict = defaultdict(dict)
+        self.hosts: Dict[str, InstillInstance] = {}
         self.namespace: str = namespace
-        if constant.DEFAULT_INSTANCE in global_config.hosts:
-            self.instance = constant.DEFAULT_INSTANCE
+        if DEFAULT_INSTANCE in global_config.hosts:
+            self.instance = DEFAULT_INSTANCE
         elif len(global_config.hosts) == 0:
             self.instance = ""
         else:
@@ -36,35 +34,19 @@ class PipelineClient(Client):
 
         if global_config.hosts is not None:
             for instance, config in global_config.hosts.items():
-                if not config.secure:
-                    channel = grpc.insecure_channel(config.url)
-                    self.hosts[instance]["metadata"] = (
-                        (
-                            "authorization",
-                            f"Bearer {config.token}",
-                        ),
-                    )
-                else:
-                    ssl_creds = grpc.ssl_channel_credentials()
-                    call_creds = grpc.access_token_call_credentials(config.token)
-                    creds = grpc.composite_channel_credentials(ssl_creds, call_creds)
-                    channel = grpc.secure_channel(
-                        target=config.url,
-                        credentials=creds,
-                    )
-                    self.hosts[instance]["metadata"] = ""
-                self.hosts[instance]["token"] = config.token
-                self.hosts[instance]["channel"] = channel
-                self.hosts[instance][
-                    "client"
-                ] = pipeline_service.PipelinePublicServiceStub(channel)
+                self.hosts[instance] = InstillInstance(
+                    config.url,
+                    config.token,
+                    config.secure,
+                    pipeline_service.PipelinePublicServiceStub,
+                )
 
     @property
     def hosts(self):
         return self._hosts
 
     @hosts.setter
-    def hosts(self, hosts: str):
+    def hosts(self, hosts: Dict[str, InstillInstance]):
         self._hosts = hosts
 
     @property
@@ -84,15 +66,15 @@ class PipelineClient(Client):
         self._metadata = metadata
 
     def liveness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: pipeline_interface.LivenessResponse = self.hosts[self.instance][
-            "client"
-        ].Liveness(request=pipeline_interface.LivenessRequest())
+        resp: pipeline_interface.LivenessResponse = self.hosts[
+            self.instance
+        ].client.Liveness(request=pipeline_interface.LivenessRequest())
         return resp.health_check_response.status
 
     def readiness(self) -> healthcheck.HealthCheckResponse.ServingStatus:
-        resp: pipeline_interface.ReadinessResponse = self.hosts[self.instance][
-            "client"
-        ].Readiness(request=pipeline_interface.ReadinessRequest())
+        resp: pipeline_interface.ReadinessResponse = self.hosts[
+            self.instance
+        ].client.Readiness(request=pipeline_interface.ReadinessRequest())
         return resp.health_check_response.status
 
     def is_serving(self) -> bool:
@@ -113,14 +95,14 @@ class PipelineClient(Client):
     ) -> Tuple[Iterable, str, int]:
         resp: operator_interface.ListOperatorDefinitionsResponse = self.hosts[
             self.instance
-        ]["client"].ListUserPipelines(
+        ].client.ListUserPipelines(
             request=operator_interface.ListOperatorDefinitionsRequest(
                 filter=filer_str,
                 page_size=total_size,
                 page_token=next_page_token,
                 view=operator_interface.ListOperatorDefinitionsRequest.VIEW_FULL,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
         return resp.operator_definitions, resp.next_page_token, resp.total_size
@@ -131,12 +113,12 @@ class PipelineClient(Client):
     ) -> operator_interface.OperatorDefinition:
         resp: operator_interface.GetOperatorDefinitionResponse = self.hosts[
             self.instance
-        ]["client"].GetOperatorDefinition(
+        ].client.GetOperatorDefinition(
             request=operator_interface.GetOperatorDefinitionRequest(
                 name=f"operator-definitions//{name}",
                 view=operator_interface.GetOperatorDefinitionRequest.VIEW_FULL,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.operator_definition
 
@@ -150,51 +132,51 @@ class PipelineClient(Client):
             id=name,
             recipe=recipe,
         )
-        resp: pipeline_interface.CreateUserPipelineResponse = self.hosts[self.instance][
-            "client"
-        ].CreateUserPipeline(
+        resp: pipeline_interface.CreateUserPipelineResponse = self.hosts[
+            self.instance
+        ].client.CreateUserPipeline(
             request=pipeline_interface.CreateUserPipelineRequest(
                 pipeline=pipeline, parent=self.namespace
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.pipeline
 
     @grpc_handler
     def get_pipeline(self, name: str) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.GetUserPipelineResponse = self.hosts[self.instance][
-            "client"
-        ].GetUserPipeline(
+        resp: pipeline_interface.GetUserPipelineResponse = self.hosts[
+            self.instance
+        ].client.GetUserPipeline(
             request=pipeline_interface.GetUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.pipeline
 
     @grpc_handler
     def lookup_pipeline(self, pipeline_uid: str) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.LookUpPipelineResponse = self.hosts[self.instance][
-            "client"
-        ].LookUpPipeline(
+        resp: pipeline_interface.LookUpPipelineResponse = self.hosts[
+            self.instance
+        ].client.LookUpPipeline(
             request=pipeline_interface.LookUpPipelineRequest(
                 permalink=f"pipelines/{pipeline_uid}",
                 view=pipeline_interface.LookUpPipelineRequest.VIEW_FULL,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.pipeline
 
     @grpc_handler
     def rename_pipeline(self, name: str, new_name: str) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.RenameUserPipelineResponse = self.hosts[self.instance][
-            "client"
-        ].RenameUserPipeline(
+        resp: pipeline_interface.RenameUserPipelineResponse = self.hosts[
+            self.instance
+        ].client.RenameUserPipeline(
             request=pipeline_interface.RenameUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}",
                 new_pipeline_id=new_name,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.pipeline
 
@@ -202,14 +184,14 @@ class PipelineClient(Client):
     def update_pipeline(
         self, pipeline: pipeline_interface.Pipeline, mask: field_mask_pb2.FieldMask
     ) -> pipeline_interface.Pipeline:
-        resp: pipeline_interface.UpdateUserPipelineResponse = self.hosts[self.instance][
-            "client"
-        ].UpdateUserPipeline(
+        resp: pipeline_interface.UpdateUserPipelineResponse = self.hosts[
+            self.instance
+        ].client.UpdateUserPipeline(
             request=pipeline_interface.UpdateUserPipelineRequest(
                 pipeline=pipeline,
                 update_mask=mask,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.pipeline
 
@@ -217,11 +199,11 @@ class PipelineClient(Client):
     def validate_pipeline(self, name: str) -> pipeline_interface.Pipeline:
         resp: pipeline_interface.ValidateUserPipelineResponse = self.hosts[
             self.instance
-        ]["client"].ValidateUserPipeline(
+        ].client.ValidateUserPipeline(
             request=pipeline_interface.ValidateUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.pipeline
 
@@ -231,11 +213,25 @@ class PipelineClient(Client):
     ) -> Tuple[Iterable, pipeline_interface.TriggerMetadata]:
         resp: pipeline_interface.TriggerUserPipelineResponse = self.hosts[
             self.instance
-        ]["client"].TriggerUserPipeline(
+        ].client.TriggerUserPipeline(
             request=pipeline_interface.TriggerUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
+        )
+        return resp.outputs, resp.metadata
+
+    @grpc_handler
+    async def trigger_asyncio_pipeline(
+        self, name: str, inputs: list
+    ) -> Tuple[Iterable, pipeline_interface.TriggerMetadata]:
+        resp: pipeline_interface.TriggerUserPipelineResponse = await self.hosts[
+            self.instance
+        ].async_client.TriggerUserPipeline(
+            request=pipeline_interface.TriggerUserPipelineRequest(
+                name=f"{self.namespace}/pipelines/{name}", inputs=inputs
+            ),
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.outputs, resp.metadata
 
@@ -245,21 +241,21 @@ class PipelineClient(Client):
     ) -> operations_pb2.Operation:
         resp: pipeline_interface.TriggerAsyncUserPipelineResponse = self.hosts[
             self.instance
-        ]["client"].TriggerAsyncUserPipeline(
+        ].client.TriggerAsyncUserPipeline(
             request=pipeline_interface.TriggerAsyncUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.operation
 
     @grpc_handler
     def delete_pipeline(self, name: str):
-        self.hosts[self.instance]["client"].DeleteUserPipeline(
+        self.hosts[self.instance].client.DeleteUserPipeline(
             request=pipeline_interface.DeleteUserPipelineRequest(
                 name=f"{self.namespace}/pipelines/{name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
@@ -276,7 +272,7 @@ class PipelineClient(Client):
             pipeline_interface.ListUserPipelinesResponse,
         ]
         if not public:
-            resp = self.hosts[self.instance]["client"].ListUserPipelines(
+            resp = self.hosts[self.instance].client.ListUserPipelines(
                 request=pipeline_interface.ListUserPipelinesRequest(
                     parent=self.namespace,
                     filter=filer_str,
@@ -285,10 +281,10 @@ class PipelineClient(Client):
                     show_deleted=show_deleted,
                     view=pipeline_interface.ListUserPipelinesRequest.VIEW_FULL,
                 ),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
         else:
-            resp = self.hosts[self.instance]["client"].ListPipelines(
+            resp = self.hosts[self.instance].client.ListPipelines(
                 request=pipeline_interface.ListPipelinesRequest(
                     filter=filer_str,
                     page_size=total_size,
@@ -296,20 +292,20 @@ class PipelineClient(Client):
                     show_deleted=show_deleted,
                     view=pipeline_interface.ListPipelinesRequest.VIEW_FULL,
                 ),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
 
         return resp.pipelines, resp.next_page_token, resp.total_size
 
     @grpc_handler
     def get_operation(self, name: str) -> operations_pb2.Operation:
-        resp: pipeline_interface.GetOperationResponse = self.hosts[self.instance][
-            "client"
-        ].GetOperation(
+        resp: pipeline_interface.GetOperationResponse = self.hosts[
+            self.instance
+        ].client.GetOperation(
             request=pipeline_interface.GetOperationRequest(
                 name=name,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.operation
 
@@ -331,11 +327,11 @@ class PipelineClient(Client):
         )
         resp: pipeline_interface.CreateUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].CreateUserPipelineRelease(
+        ].client.CreateUserPipelineRelease(
             request=pipeline_interface.CreateUserPipelineReleaseRequest(
                 release=pipeline_release, parent=self.namespace
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.release
 
@@ -351,12 +347,12 @@ class PipelineClient(Client):
         """
         resp: pipeline_interface.GetUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].GetUserPipelineRelease(
+        ].client.GetUserPipelineRelease(
             request=pipeline_interface.GetUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
                 view=pipeline_interface.GetUserPipelineReleaseRequest.VIEW_FULL,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.release
 
@@ -375,12 +371,12 @@ class PipelineClient(Client):
         """
         resp: pipeline_interface.RenameUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].RenameUserPipelineRelease(
+        ].client.RenameUserPipelineRelease(
             request=pipeline_interface.RenameUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
                 new_pipeline_release_id=new_version,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.release
 
@@ -392,12 +388,12 @@ class PipelineClient(Client):
     ) -> pipeline_interface.PipelineRelease:
         resp: pipeline_interface.UpdateUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].UpdateUserPipelineRelease(
+        ].client.UpdateUserPipelineRelease(
             request=pipeline_interface.UpdateUserPipelineReleaseRequest(
                 release=pipeline_release,
                 update_mask=mask,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.release
 
@@ -411,7 +407,7 @@ class PipelineClient(Client):
     ) -> Tuple[Iterable, str, int]:
         resp: pipeline_interface.ListUserPipelineReleasesResponse = self.hosts[
             self.instance
-        ]["client"].ListUserPipelineReleases(
+        ].client.ListUserPipelineReleases(
             request=pipeline_interface.ListUserPipelineReleasesRequest(
                 parent=self.namespace,
                 filter=filer_str,
@@ -420,18 +416,18 @@ class PipelineClient(Client):
                 show_deleted=show_deleted,
                 view=pipeline_interface.ListUserPipelineReleasesRequest.VIEW_FULL,
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
         return resp.releases, resp.next_page_token, resp.total_size
 
     @grpc_handler
     def delete_pipeline_release(self, name: str):
-        self.hosts[self.instance]["client"].DeleteUserPipelineRelease(
+        self.hosts[self.instance].client.DeleteUserPipelineRelease(
             request=pipeline_interface.DeleteUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
@@ -440,11 +436,11 @@ class PipelineClient(Client):
     ) -> pipeline_interface.PipelineRelease:
         resp: pipeline_interface.SetDefaultUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].SetDefaultUserPipelineRelease(
+        ].client.SetDefaultUserPipelineRelease(
             request=pipeline_interface.SetDefaultUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.release
 
@@ -452,11 +448,11 @@ class PipelineClient(Client):
     def restore_pipeline_release(self, name: str) -> pipeline_interface.PipelineRelease:
         resp: pipeline_interface.RestoreUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].RestoreUserPipelineRelease(
+        ].client.RestoreUserPipelineRelease(
             request=pipeline_interface.RestoreUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.release
 
@@ -464,11 +460,11 @@ class PipelineClient(Client):
     def watch_pipeline_release(self, name: str) -> pipeline_interface.State.ValueType:
         resp: pipeline_interface.WatchUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].WatchUserPipelineRelease(
+        ].client.WatchUserPipelineRelease(
             request=pipeline_interface.WatchUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}",
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.state
 
@@ -478,11 +474,11 @@ class PipelineClient(Client):
     ) -> Tuple[Iterable, pipeline_interface.TriggerMetadata]:
         resp: pipeline_interface.TriggerUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].TriggerUserPipelineReleas(
+        ].client.TriggerUserPipelineReleas(
             request=pipeline_interface.TriggerUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.outputs, resp.metadata
 
@@ -492,11 +488,11 @@ class PipelineClient(Client):
     ) -> operations_pb2.Operation:
         resp: pipeline_interface.TriggerAsyncUserPipelineReleaseResponse = self.hosts[
             self.instance
-        ]["client"].TriggerAsyncUserPipelineRelease(
+        ].client.TriggerAsyncUserPipelineRelease(
             request=pipeline_interface.TriggerAsyncUserPipelineReleaseRequest(
                 name=f"{self.namespace}/pipelines/{name}", inputs=inputs
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
         return resp.operation
 
@@ -511,11 +507,11 @@ class PipelineClient(Client):
         connector.id = name
         connector.connector_definition_name = definition
         connector.configuration.update(configuration)
-        resp = self.hosts[self.instance]["client"].CreateUserConnector(
+        resp = self.hosts[self.instance].client.CreateUserConnector(
             request=connector_interface.CreateUserConnectorRequest(
                 connector=connector, parent=self.namespace
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
         return resp.connector
@@ -523,13 +519,13 @@ class PipelineClient(Client):
     @grpc_handler
     def get_connector(self, name: str) -> connector_interface.Connector:
         return (
-            self.hosts[self.instance]["client"]
-            .GetUserConnector(
+            self.hosts[self.instance]
+            .client.GetUserConnector(
                 request=connector_interface.GetUserConnectorRequest(
                     name=f"{self.namespace}/connectors/{name}",
                     view=connector_interface.GetUserConnectorRequest.VIEW_FULL,
                 ),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
             .connector
         )
@@ -537,12 +533,12 @@ class PipelineClient(Client):
     @grpc_handler
     def test_connector(self, name: str) -> connector_interface.Connector.State:
         return (
-            self.hosts[self.instance]["client"]
-            .TestUserConnector(
+            self.hosts[self.instance]
+            .client.TestUserConnector(
                 request=connector_interface.TestUserConnectorRequest(
                     name=f"{self.namespace}/connectors/{name}"
                 ),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
             .state
         )
@@ -550,12 +546,12 @@ class PipelineClient(Client):
     @grpc_handler
     def execute_connector(self, name: str, inputs: list) -> list:
         return (
-            self.hosts[self.instance]["client"]
-            .ExecuteUserConnector(
+            self.hosts[self.instance]
+            .client.ExecuteUserConnector(
                 request=connector_interface.ExecuteUserConnectorRequest(
                     name=f"{self.namespace}/connectors/{name}", inputs=inputs
                 ),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
             .outputs
         )
@@ -563,38 +559,38 @@ class PipelineClient(Client):
     @grpc_handler
     def watch_connector(self, name: str) -> connector_interface.Connector.State:
         return (
-            self.hosts[self.instance]["client"]
-            .WatchUserConnector(
+            self.hosts[self.instance]
+            .client.WatchUserConnector(
                 request=connector_interface.WatchUserConnectorRequest(
                     name=f"{self.namespace}/connectors/{name}"
                 ),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
             .state
         )
 
     @grpc_handler
     def delete_connector(self, name: str):
-        self.hosts[self.instance]["client"].DeleteUserConnector(
+        self.hosts[self.instance].client.DeleteUserConnector(
             request=connector_interface.DeleteUserConnectorRequest(
                 name=f"{self.namespace}/connectors/{name}"
             ),
-            metadata=self.hosts[self.instance]["metadata"],
+            metadata=self.hosts[self.instance].metadata,
         )
 
     @grpc_handler
     def list_connectors(self, public=False) -> Tuple[list, str, int]:
         if not public:
-            resp = self.hosts[self.instance]["client"].ListUserConnectors(
+            resp = self.hosts[self.instance].client.ListUserConnectors(
                 request=connector_interface.ListUserConnectorsRequest(
                     parent=self.namespace
                 ),
-                metadata=self.hosts[self.instance]["metadata"],
+                metadata=self.hosts[self.instance].metadata,
             )
         else:
-            resp = self.hosts[self.instance]["client"].ListConnectors(
+            resp = self.hosts[self.instance].client.ListConnectors(
                 request=connector_interface.ListConnectorsRequest(),
-                metadata=(self.hosts[self.instance]["metadata"],),
+                metadata=(self.hosts[self.instance].metadata,),
             )
 
         return resp.connectors, resp.next_page_token, resp.total_size

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -398,8 +398,18 @@ class PipelineClient(Client):
         if async_enabled:
             if public:
                 method = self.hosts[self.instance].async_client.ListPipelines
-            else:
-                method = self.hosts[self.instance].async_client.ListUserPipelines
+                return RequestFactory(
+                    method=method,
+                    request=pipeline_interface.ListPipelinesRequest(
+                        filter=filer_str,
+                        page_size=total_size,
+                        page_token=next_page_token,
+                        show_deleted=show_deleted,
+                        view=pipeline_interface.ListPipelinesRequest.VIEW_FULL,
+                    ),
+                    metadata=self.hosts[self.instance].metadata,
+                ).send_async()
+            method = self.hosts[self.instance].async_client.ListUserPipelines
             return RequestFactory(
                 method=method,
                 request=pipeline_interface.ListUserPipelinesRequest(
@@ -414,8 +424,18 @@ class PipelineClient(Client):
             ).send_async()
         if public:
             method = self.hosts[self.instance].client.ListPipelines
-        else:
-            method = self.hosts[self.instance].client.ListUserPipelines
+            return RequestFactory(
+                method=method,
+                request=pipeline_interface.ListPipelinesRequest(
+                    filter=filer_str,
+                    page_size=total_size,
+                    page_token=next_page_token,
+                    show_deleted=show_deleted,
+                    view=pipeline_interface.ListPipelinesRequest.VIEW_FULL,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_sync()
+        method = self.hosts[self.instance].client.ListUserPipelines
         return RequestFactory(
             method=method,
             request=pipeline_interface.ListUserPipelinesRequest(
@@ -922,8 +942,18 @@ class PipelineClient(Client):
         if async_enabled:
             if public:
                 method = self.hosts[self.instance].async_client.ListConnectors
-            else:
-                method = self.hosts[self.instance].async_client.ListUserConnectors
+                return RequestFactory(
+                    method=method,
+                    request=connector_interface.ListConnectorsRequest(
+                        filter=filer_str,
+                        page_size=total_size,
+                        page_token=next_page_token,
+                        show_deleted=show_deleted,
+                        view=connector_interface.ListConnectorsRequest.VIEW_FULL,
+                    ),
+                    metadata=self.hosts[self.instance].metadata,
+                ).send_async()
+            method = self.hosts[self.instance].async_client.ListUserConnectors
             return RequestFactory(
                 method=method,
                 request=connector_interface.ListUserConnectorsRequest(
@@ -938,8 +968,18 @@ class PipelineClient(Client):
             ).send_async()
         if public:
             method = self.hosts[self.instance].client.ListConnectors
-        else:
-            method = self.hosts[self.instance].client.ListUserConnectors
+            return RequestFactory(
+                method=method,
+                request=connector_interface.ListConnectorsRequest(
+                    filter=filer_str,
+                    page_size=total_size,
+                    page_token=next_page_token,
+                    show_deleted=show_deleted,
+                    view=connector_interface.ListConnectorsRequest.VIEW_FULL,
+                ),
+                metadata=self.hosts[self.instance].metadata,
+            ).send_sync()
+        method = self.hosts[self.instance].client.ListUserConnectors
         return RequestFactory(
             method=method,
             request=connector_interface.ListUserConnectorsRequest(

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -65,7 +65,9 @@ class PipelineClient(Client):
     def metadata(self, metadata: str):
         self._metadata = metadata
 
-    def liveness(self, async_enabled: bool = False) -> healthcheck.HealthCheckResponse:
+    def liveness(
+        self, async_enabled: bool = False
+    ) -> pipeline_interface.LivenessResponse:
         if async_enabled:
             return RequestFactory(
                 method=self.hosts[self.instance].async_client.Liveness,
@@ -79,7 +81,9 @@ class PipelineClient(Client):
             metadata=self.hosts[self.instance].metadata,
         ).send_sync()
 
-    def readiness(self, async_enabled: bool = False) -> healthcheck.HealthCheckResponse:
+    def readiness(
+        self, async_enabled: bool = False
+    ) -> pipeline_interface.ReadinessResponse:
         if async_enabled:
             return RequestFactory(
                 method=self.hosts[self.instance].async_client.Readiness,
@@ -96,7 +100,7 @@ class PipelineClient(Client):
     def is_serving(self) -> bool:
         try:
             return (
-                self.readiness().status
+                self.readiness().health_check_response.status
                 == healthcheck.HealthCheckResponse.SERVING_STATUS_SERVING
             )
         except Exception:

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -22,7 +22,7 @@ from instill.utils.error_handler import grpc_handler
 
 
 class PipelineClient(Client):
-    def __init__(self, namespace: str, asyncio: bool) -> None:
+    def __init__(self, namespace: str, async_enabled: bool) -> None:
         self.hosts: Dict[str, InstillInstance] = {}
         self.namespace: str = namespace
         if DEFAULT_INSTANCE in global_config.hosts:
@@ -39,7 +39,7 @@ class PipelineClient(Client):
                     url=config.url,
                     token=config.token,
                     secure=config.secure,
-                    asyncio=asyncio,
+                    async_enabled=async_enabled,
                 )
 
     @property

--- a/instill/tests/test_client.py
+++ b/instill/tests/test_client.py
@@ -1,49 +1,118 @@
 # pylint: disable=redefined-outer-name,unused-variable,expression-not-assigned,no-name-in-module
 
-from collections import defaultdict
-
+import instill.protogen.core.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
+import instill.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
+import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
 from instill.clients import MgmtClient, ModelClient, PipelineClient
+from instill.clients.instance import InstillInstance
 
 
 def describe_client():
     def describe_instance():
         def when_not_set(expect):
-            mgmt_client = MgmtClient()
+            mgmt_client = MgmtClient(False)
             expect(mgmt_client.instance) == ""
-            model_client = ModelClient(namespace="")
+            model_client = ModelClient(namespace="", asyncio=False)
             expect(model_client.instance) == ""
-            pipeline_client = PipelineClient(namespace="")
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
             expect(pipeline_client.instance) == ""
 
         def when_set_correct_type(expect):
-            mgmt_client = MgmtClient()
+            mgmt_client = MgmtClient(False)
             mgmt_client.instance = "staging"
             expect(mgmt_client.instance) == "staging"
-            model_client = ModelClient(namespace="")
+            model_client = ModelClient(namespace="", asyncio=False)
             model_client.instance = "staging"
             expect(model_client.instance) == "staging"
-            pipeline_client = PipelineClient(namespace="")
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
             pipeline_client.instance = "staging"
             expect(pipeline_client.instance) == "staging"
 
     def describe_host():
         def when_not_set(expect):
-            mgmt_client = MgmtClient()
+            mgmt_client = MgmtClient(False)
             expect(mgmt_client.hosts) is None
-            model_client = ModelClient(namespace="")
+            model_client = ModelClient(namespace="", asyncio=False)
             expect(model_client.hosts) is None
-            pipeline_client = PipelineClient(namespace="")
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
             expect(pipeline_client.hosts) is None
 
-        def when_set_correct_type(expect):
-            mgmt_client = MgmtClient()
-            d = defaultdict(dict)  # type: ignore
-            d["test_instance"] = dict({"url": "test_url"})
-            mgmt_client.hosts = d
-            expect(mgmt_client.hosts["test_instance"]["url"]) == "test_url"
-            model_client = ModelClient(namespace="")
-            model_client.hosts = d
-            expect(model_client.hosts["test_instance"]["url"]) == "test_url"
-            pipeline_client = PipelineClient(namespace="")
-            pipeline_client.hosts = d
-            expect(pipeline_client.hosts["test_instance"]["url"]) == "test_url"
+        def when_set_correct_type_url(expect):
+            mgmt_instance = {
+                "test_instance": InstillInstance(
+                    mgmt_service.MgmtPublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            mgmt_client = MgmtClient(False)
+            mgmt_client.hosts = mgmt_instance
+            expect(mgmt_client.hosts["test_instance"].url) == "test_url"
+
+            model_instance = {
+                "test_instance": InstillInstance(
+                    model_service.ModelPublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            model_client = ModelClient(namespace="", asyncio=False)
+            model_client.hosts = model_instance
+            expect(model_client.hosts["test_instance"].url) == "test_url"
+
+            pipeline_instance = {
+                "test_instance": InstillInstance(
+                    pipeline_service.PipelinePublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client.hosts = pipeline_instance
+            expect(pipeline_client.hosts["test_instance"].url) == "test_url"
+
+        def when_set_correct_type_token(expect):
+            mgmt_instance = {
+                "test_instance": InstillInstance(
+                    mgmt_service.MgmtPublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            mgmt_client = MgmtClient(False)
+            mgmt_client.hosts = mgmt_instance
+            expect(mgmt_client.hosts["test_instance"].token) == "token"
+
+            model_instance = {
+                "test_instance": InstillInstance(
+                    model_service.ModelPublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            model_client = ModelClient(namespace="", asyncio=False)
+            model_client.hosts = model_instance
+            expect(model_client.hosts["test_instance"].token) == "token"
+
+            pipeline_instance = {
+                "test_instance": InstillInstance(
+                    pipeline_service.PipelinePublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client.hosts = pipeline_instance
+            expect(pipeline_client.hosts["test_instance"].token) == "token"

--- a/instill/tests/test_client.py
+++ b/instill/tests/test_client.py
@@ -12,19 +12,19 @@ def describe_client():
         def when_not_set(expect):
             mgmt_client = MgmtClient(False)
             expect(mgmt_client.instance) == ""
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             expect(model_client.instance) == ""
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             expect(pipeline_client.instance) == ""
 
         def when_set_correct_type(expect):
             mgmt_client = MgmtClient(False)
             mgmt_client.instance = "staging"
             expect(mgmt_client.instance) == "staging"
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             model_client.instance = "staging"
             expect(model_client.instance) == "staging"
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             pipeline_client.instance = "staging"
             expect(pipeline_client.instance) == "staging"
 
@@ -32,9 +32,9 @@ def describe_client():
         def when_not_set(expect):
             mgmt_client = MgmtClient(False)
             expect(mgmt_client.hosts) is None
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             expect(model_client.hosts) is None
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             expect(pipeline_client.hosts) is None
 
         def when_set_correct_type_url(expect):
@@ -60,7 +60,7 @@ def describe_client():
                     False,
                 )
             }
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             model_client.hosts = model_instance
             expect(model_client.hosts["test_instance"].url) == "test_url"
 
@@ -73,7 +73,7 @@ def describe_client():
                     False,
                 )
             }
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             pipeline_client.hosts = pipeline_instance
             expect(pipeline_client.hosts["test_instance"].url) == "test_url"
 
@@ -100,7 +100,7 @@ def describe_client():
                     False,
                 )
             }
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             model_client.hosts = model_instance
             expect(model_client.hosts["test_instance"].token) == "token"
 
@@ -113,6 +113,6 @@ def describe_client():
                     False,
                 )
             }
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             pipeline_client.hosts = pipeline_instance
             expect(pipeline_client.hosts["test_instance"].token) == "token"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,49 +1,118 @@
 # pylint: disable=redefined-outer-name,unused-variable,expression-not-assigned,no-name-in-module
 
-from collections import defaultdict
-
+import instill.protogen.core.mgmt.v1alpha.mgmt_public_service_pb2_grpc as mgmt_service
+import instill.protogen.model.model.v1alpha.model_public_service_pb2_grpc as model_service
+import instill.protogen.vdp.pipeline.v1alpha.pipeline_public_service_pb2_grpc as pipeline_service
 from instill.clients import MgmtClient, ModelClient, PipelineClient
+from instill.clients.instance import InstillInstance
 
 
 def describe_client():
     def describe_instance():
         def when_not_set(expect):
-            mgmt_client = MgmtClient()
+            mgmt_client = MgmtClient(False)
             expect(mgmt_client.instance) == ""
-            model_client = ModelClient(namespace="")
+            model_client = ModelClient(namespace="", asyncio=False)
             expect(model_client.instance) == ""
-            pipeline_client = PipelineClient(namespace="")
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
             expect(pipeline_client.instance) == ""
 
         def when_set_correct_type(expect):
-            mgmt_client = MgmtClient()
+            mgmt_client = MgmtClient(False)
             mgmt_client.instance = "staging"
             expect(mgmt_client.instance) == "staging"
-            model_client = ModelClient(namespace="")
+            model_client = ModelClient(namespace="", asyncio=False)
             model_client.instance = "staging"
             expect(model_client.instance) == "staging"
-            pipeline_client = PipelineClient(namespace="")
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
             pipeline_client.instance = "staging"
             expect(pipeline_client.instance) == "staging"
 
     def describe_host():
         def when_not_set(expect):
-            mgmt_client = MgmtClient()
+            mgmt_client = MgmtClient(False)
             expect(mgmt_client.hosts) is None
-            model_client = ModelClient(namespace="")
+            model_client = ModelClient(namespace="", asyncio=False)
             expect(model_client.hosts) is None
-            pipeline_client = PipelineClient(namespace="")
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
             expect(pipeline_client.hosts) is None
 
-        def when_set_correct_type(expect):
-            mgmt_client = MgmtClient()
-            d = defaultdict(dict)  # type: ignore
-            d["test_instance"] = dict({"url": "test_url"})
-            mgmt_client.hosts = d
-            expect(mgmt_client.hosts["test_instance"]["url"]) == "test_url"
-            model_client = ModelClient(namespace="")
-            model_client.hosts = d
-            expect(model_client.hosts["test_instance"]["url"]) == "test_url"
-            pipeline_client = PipelineClient(namespace="")
-            pipeline_client.hosts = d
-            expect(pipeline_client.hosts["test_instance"]["url"]) == "test_url"
+        def when_set_correct_type_url(expect):
+            mgmt_instance = {
+                "test_instance": InstillInstance(
+                    mgmt_service.MgmtPublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            mgmt_client = MgmtClient(False)
+            mgmt_client.hosts = mgmt_instance
+            expect(mgmt_client.hosts["test_instance"].url) == "test_url"
+
+            model_instance = {
+                "test_instance": InstillInstance(
+                    model_service.ModelPublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            model_client = ModelClient(namespace="", asyncio=False)
+            model_client.hosts = model_instance
+            expect(model_client.hosts["test_instance"].url) == "test_url"
+
+            pipeline_instance = {
+                "test_instance": InstillInstance(
+                    pipeline_service.PipelinePublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client.hosts = pipeline_instance
+            expect(pipeline_client.hosts["test_instance"].url) == "test_url"
+
+        def when_set_correct_type_token(expect):
+            mgmt_instance = {
+                "test_instance": InstillInstance(
+                    mgmt_service.MgmtPublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            mgmt_client = MgmtClient(False)
+            mgmt_client.hosts = mgmt_instance
+            expect(mgmt_client.hosts["test_instance"].token) == "token"
+
+            model_instance = {
+                "test_instance": InstillInstance(
+                    model_service.ModelPublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            model_client = ModelClient(namespace="", asyncio=False)
+            model_client.hosts = model_instance
+            expect(model_client.hosts["test_instance"].token) == "token"
+
+            pipeline_instance = {
+                "test_instance": InstillInstance(
+                    pipeline_service.PipelinePublicServiceStub,
+                    "test_url",
+                    "token",
+                    False,
+                    False,
+                )
+            }
+            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client.hosts = pipeline_instance
+            expect(pipeline_client.hosts["test_instance"].token) == "token"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,19 +12,19 @@ def describe_client():
         def when_not_set(expect):
             mgmt_client = MgmtClient(False)
             expect(mgmt_client.instance) == ""
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             expect(model_client.instance) == ""
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             expect(pipeline_client.instance) == ""
 
         def when_set_correct_type(expect):
             mgmt_client = MgmtClient(False)
             mgmt_client.instance = "staging"
             expect(mgmt_client.instance) == "staging"
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             model_client.instance = "staging"
             expect(model_client.instance) == "staging"
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             pipeline_client.instance = "staging"
             expect(pipeline_client.instance) == "staging"
 
@@ -32,9 +32,9 @@ def describe_client():
         def when_not_set(expect):
             mgmt_client = MgmtClient(False)
             expect(mgmt_client.hosts) is None
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             expect(model_client.hosts) is None
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             expect(pipeline_client.hosts) is None
 
         def when_set_correct_type_url(expect):
@@ -60,7 +60,7 @@ def describe_client():
                     False,
                 )
             }
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             model_client.hosts = model_instance
             expect(model_client.hosts["test_instance"].url) == "test_url"
 
@@ -73,7 +73,7 @@ def describe_client():
                     False,
                 )
             }
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             pipeline_client.hosts = pipeline_instance
             expect(pipeline_client.hosts["test_instance"].url) == "test_url"
 
@@ -100,7 +100,7 @@ def describe_client():
                     False,
                 )
             }
-            model_client = ModelClient(namespace="", asyncio=False)
+            model_client = ModelClient(namespace="", async_enabled=False)
             model_client.hosts = model_instance
             expect(model_client.hosts["test_instance"].token) == "token"
 
@@ -113,6 +113,6 @@ def describe_client():
                     False,
                 )
             }
-            pipeline_client = PipelineClient(namespace="", asyncio=False)
+            pipeline_client = PipelineClient(namespace="", async_enabled=False)
             pipeline_client.hosts = pipeline_instance
             expect(pipeline_client.hosts["test_instance"].token) == "token"


### PR DESCRIPTION
Because

- add `asyncio` support for IO bound request tasks

This commit

- add `asyncio` support in each endpoint
- refactor `client` return type to align with protobuf message
- add `instance` class to provide better type hinting
- remove global client to avoid event_loop collision between `sync` and `async` clients
- misc fixes

fixes INS-2793
fixes INS-2800
fixes INS-2142