### PR TITLE
fix(ray): allow cwd as runtime env

### DIFF
--- a/instill/helpers/const.py
+++ b/instill/helpers/const.py
@@ -1,5 +1,4 @@
 import os
-
 from enum import Enum
 from typing import Any, Dict, Union
 

--- a/instill/helpers/const.py
+++ b/instill/helpers/const.py
@@ -1,3 +1,5 @@
+import os
+
 from enum import Enum
 from typing import Any, Dict, Union
 
@@ -78,5 +80,10 @@ DEFAULT_AUTOSCALING_CONFIG = {
     "initial_replicas": 1,
     "min_replicas": 0,
     "max_replicas": 5,
+}
+DEFAULT_RUNTIME_ENV = {
+    "env_vars": {
+        "PYTHONPATH": os.getcwd(),
+    },
 }
 DEFAULT_MAX_CONCURRENT_QUERIES = 10

--- a/instill/helpers/ray_config.py
+++ b/instill/helpers/ray_config.py
@@ -10,6 +10,7 @@ from instill.helpers.const import (
     DEFAULT_AUTOSCALING_CONFIG,
     DEFAULT_MAX_CONCURRENT_QUERIES,
     DEFAULT_RAY_ACTOR_OPRTIONS,
+    DEFAULT_RUNTIME_ENV,
 )
 
 
@@ -107,7 +108,7 @@ class InstillDeployable:
     def deploy(self, model_folder_path: str, ray_addr: str):
         if not ray.is_initialized():
             ray_addr = "ray://" + ray_addr.replace("9000", "10001")
-            ray.init(ray_addr)
+            ray.init(address=ray_addr, runtime_env=DEFAULT_RUNTIME_ENV)
         model_path = "/".join([model_folder_path, self.model_weight_or_folder_name])
         model_path_string_parts = model_path.split("/")
         application_name = model_path_string_parts[5]
@@ -122,7 +123,7 @@ class InstillDeployable:
     def undeploy(self, model_folder_path: str, ray_addr: str):
         if not ray.is_initialized():
             ray_addr = "ray://" + ray_addr.replace("9000", "10001")
-            ray.init(ray_addr)
+            ray.init(address=ray_addr, runtime_env=DEFAULT_RUNTIME_ENV)
         model_path = "/".join([model_folder_path, self.model_weight_or_folder_name])
         model_path_string_parts = model_path.split("/")
         model_name = "_".join(model_path_string_parts[3].split("#")[:2])

--- a/notebooks/asyncio_example.py
+++ b/notebooks/asyncio_example.py
@@ -1,11 +1,12 @@
 import asyncio
-import time
 import base64
+import time
+
 import requests
 from google.protobuf.struct_pb2 import Struct
 
-from instill.configuration import global_config
 from instill.clients import InstillClient
+from instill.configuration import global_config
 
 global_config.set_default(
     url="localhost:8080",


### PR DESCRIPTION
Because

- some models will need packages in current directory as dependencies

This commit

- allow current working directory as runtime env
