### PR TITLE
refactor(ray)!: retire non-decorator deploy and update scaling config

### DIFF
--- a/instill/helpers/const.py
+++ b/instill/helpers/const.py
@@ -72,17 +72,21 @@ class VisualQuestionAnsweringInput:
 
 
 DEFAULT_RAY_ACTOR_OPRTIONS = {
-    "num_cpus": 1,
+    "num_cpus": 2,
 }
 DEFAULT_AUTOSCALING_CONFIG = {
-    "target_num_ongoing_requests_per_replica": 7,
+    "target_num_ongoing_requests_per_replica": 10,
     "initial_replicas": 1,
     "min_replicas": 0,
     "max_replicas": 5,
+    "upscale_delay_s": 4,
+    "downscale_delay_s": 60,
+    "metrics_interval_s": 2,
+    "look_pack_period_s": 10,
 }
 DEFAULT_RUNTIME_ENV = {
     "env_vars": {
         "PYTHONPATH": os.getcwd(),
     },
 }
-DEFAULT_MAX_CONCURRENT_QUERIES = 10
+DEFAULT_MAX_CONCURRENT_QUERIES = 15


### PR DESCRIPTION
Because

- retire non-decorator deployment method
- adjust auto scaling sensitivity

This commit

- remove non-decorator deployment config
- update auto scaling params
