### PR TITLE
feat(model): Update Text-Generation Task Schema to Align with OpenAI Standards 

### DIFF
--- a/instill/helpers/const.py
+++ b/instill/helpers/const.py
@@ -1,6 +1,6 @@
 import os
 from enum import Enum
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Union
 
 import numpy as np
 
@@ -23,11 +23,14 @@ class DataType(Enum):
 
 class TextGenerationInput:
     prompt = ""
+    prompt_images: Union[List[np.ndarray], None] = None
+    chat_history: Union[List[str], None] = None
+    system_message: Union[str, None] = None
     max_new_tokens = 100
-    top_k = 1
     temperature = 0.8
+    top_k = 1
     random_seed = 0
-    stop_words: Any = ""
+    stop_words: Any = ""  # Optional
     extra_params: Dict[str, str] = {}
 
 
@@ -53,21 +56,28 @@ class ImageToImageInput:
 
 
 class TextGenerationChatInput:
-    conversation = ""
+    prompt = ""
+    prompt_images: Union[List[np.ndarray], None] = None
+    chat_history: Union[List[str], None] = None
+    system_message: Union[str, None] = None
     max_new_tokens = 100
-    top_k = 1
     temperature = 0.8
+    top_k = 1
     random_seed = 0
+    stop_words: Any = ""  # Optional
     extra_params: Dict[str, str] = {}
 
 
 class VisualQuestionAnsweringInput:
-    prompt_image: Union[np.ndarray, None] = None
     prompt = ""
+    prompt_images: Union[List[np.ndarray], None] = None
+    chat_history: Union[List[str], None] = None
+    system_message: Union[str, None] = None
     max_new_tokens = 100
-    top_k = 1
     temperature = 0.8
+    top_k = 1
     random_seed = 0
+    stop_words: Any = ""  # Optional
     extra_params: Dict[str, str] = {}
 
 


### PR DESCRIPTION
Because ... 

- This update is necessitated by the need to align our current text-generation-task schema more closely with OpenAI's task structure.

This commit .. 

1. **Enhancement of TASK_TEXT_GENERATION**: Following our discussion in [INS-2982](https://linear.app/instill-ai/issue/INS-2982/harmonizing-the-text-generation-tasks-protocol-buffer-with-the-openai), we have introduced three new fields to the `TASK_TEXT_GENERATION` protocol buffer:
   - An optional `system_message` string.
   - An optional `chat_history` field, now mirroring the type used in `conversation`.
   - An optional `image_url` string, which is a base64 encoded string including batch dimension.

2. **Improved `extra_param` Support**: To offer enhanced functionality for the `extra_param`, we have implemented the suggestions in [INS-2954](https://linear.app/instill-ai/issue/INS-2954/improve-param-value-filed-type).

3. **Protobuf Structure Update**: In line with the recent [commit](https://github.com/instill-ai/protobufs/commit/61c3ca8eec4a60e80e1f5c5c8968647cf083fdbb) to our protobuf repository, we have migrated the `model owner` and `org` fields to a new unified `owner` field, ensuring consistency across our models.


Related changes

- [protobuf PR](https://github.com/instill-ai/protobufs/pull/243)
- [model backed PR](https://github.com/instill-ai/model-backend/pull/479)