### PR TITLE
fix(resources): fix resource schema path

### DIFF
--- a/instill/resources/const.py
+++ b/instill/resources/const.py
@@ -1,3 +1,5 @@
+import os
+
 INSTILL_MODEL_INTERNAL_MODEL = "Internal Mode"
 INSTILL_MODEL_EXTERNAL_MODEL = "External Mode"
-SPEC_PATH = "instill/resources/schema/jsons"
+SPEC_PATH = f"{os.path.dirname(__file__)}/schema/jsons"


### PR DESCRIPTION
Because

- resource schema files cannot be referenced with wrong path

This commit

- fix resource schema path
