### PR TITLE
refactor(resources): pop optional values with `None`

### DIFF
--- a/instill/resources/connector_ai.py
+++ b/instill/resources/connector_ai.py
@@ -66,11 +66,11 @@ class HuggingfaceConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: HuggingFaceConnectorSpec,
+        config_spec: HuggingFaceConnectorSpec,
     ) -> None:
         definition = "connector-definitions/hugging-face"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, StabilityAIConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -111,12 +111,12 @@ class InstillModelConnector(Connector):
     def __init__(
         self,
         client: InstillClient,
-        config: InstillModelConnectorConfig,
+        config_spec: InstillModelConnectorConfig,
         name: str = "model-connector",
     ) -> None:
         definition = "connector-definitions/instill-model"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, InstillModelConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -152,11 +152,11 @@ class StabilityAIConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: StabilityAIConnectorResource,
+        config_spec: StabilityAIConnectorResource,
     ) -> None:
         definition = "connector-definitions/stability-ai"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, StabilityAIConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -182,11 +182,11 @@ class OpenAIConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: OpenAIConnectorResource,
+        config_spec: OpenAIConnectorResource,
     ) -> None:
         definition = "connector-definitions/openai"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, OpenAIConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 

--- a/instill/resources/connector_ai.py
+++ b/instill/resources/connector_ai.py
@@ -70,8 +70,9 @@ class HuggingfaceConnector(Connector):
     ) -> None:
         definition = "connector-definitions/hugging-face"
 
-        jsonschema.validate(vars(config), StabilityAIConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, StabilityAIConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
@@ -97,7 +98,7 @@ class HuggingfaceConnector(Connector):
             huggingface_task_token_classification_input.Input,
         ],
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -115,8 +116,9 @@ class InstillModelConnector(Connector):
     ) -> None:
         definition = "connector-definitions/instill-model"
 
-        jsonschema.validate(vars(config), InstillModelConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, InstillModelConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
@@ -134,7 +136,7 @@ class InstillModelConnector(Connector):
             instill_task_visual_question_answering_input.Input,
         ],
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -154,8 +156,9 @@ class StabilityAIConnector(Connector):
     ) -> None:
         definition = "connector-definitions/stability-ai"
 
-        jsonschema.validate(vars(config), StabilityAIConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, StabilityAIConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
@@ -165,7 +168,7 @@ class StabilityAIConnector(Connector):
             stabilityai_task_text_to_image_input.Input,
         ],
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -183,8 +186,9 @@ class OpenAIConnector(Connector):
     ) -> None:
         definition = "connector-definitions/openai"
 
-        jsonschema.validate(vars(config), OpenAIConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, OpenAIConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
@@ -197,5 +201,5 @@ class OpenAIConnector(Connector):
             openai_task_text_to_speech_input.InputModel,
         ],
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)

--- a/instill/resources/connector_airbyte.py
+++ b/instill/resources/connector_airbyte.py
@@ -24,13 +24,12 @@ class AirbyteAmazonsqsConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Amazonsqs,
+        config_spec: airbyte.Amazonsqs,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteAmazonsqsConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteAmazonsqsConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -52,13 +51,12 @@ class AirbyteAwsdatalakeConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Awsdatalake,
+        config_spec: airbyte.Awsdatalake,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteAwsdatalakeConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteAwsdatalakeConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -80,10 +78,11 @@ class AirbyteAzureblobstorageConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Azureblobstorage,
+        config_spec: airbyte.Azureblobstorage,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(
             config, AirbyteAzureblobstorageConnector.definitions_jsonschema
         )
@@ -108,13 +107,12 @@ class AirbyteBigqueryConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Bigquery,
+        config_spec: airbyte.Bigquery,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteBigqueryConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteBigqueryConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -136,13 +134,12 @@ class AirbyteCassandraConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Cassandra,
+        config_spec: airbyte.Cassandra,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteCassandraConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteCassandraConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -164,11 +161,11 @@ class AirbyteChromaConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Chroma,
+        config_spec: airbyte.Chroma,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteChromaConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -191,13 +188,12 @@ class AirbyteClickhouseConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Clickhouse,
+        config_spec: airbyte.Clickhouse,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteClickhouseConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteClickhouseConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -219,11 +215,11 @@ class AirbyteConvexConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Convex,
+        config_spec: airbyte.Convex,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteConvexConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -246,11 +242,11 @@ class AirbyteCsvConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Csv,
+        config_spec: airbyte.Csv,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteCsvConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -273,13 +269,12 @@ class AirbyteCumulioConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Cumulio,
+        config_spec: airbyte.Cumulio,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteCumulioConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteCumulioConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -301,13 +296,12 @@ class AirbyteDatabendConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Databend,
+        config_spec: airbyte.Databend,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteDatabendConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteDatabendConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -329,13 +323,12 @@ class AirbyteDatabricksConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Databricks,
+        config_spec: airbyte.Databricks,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteDatabricksConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteDatabricksConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -357,11 +350,11 @@ class AirbyteDorisConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Doris,
+        config_spec: airbyte.Doris,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteDorisConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -384,11 +377,11 @@ class AirbyteDuckdbConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Duckdb,
+        config_spec: airbyte.Duckdb,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteDuckdbConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -411,13 +404,12 @@ class AirbyteDynamodbConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Dynamodb,
+        config_spec: airbyte.Dynamodb,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteDynamodbConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteDynamodbConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -439,13 +431,12 @@ class AirbyteE2etestConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.E2etest,
+        config_spec: airbyte.E2etest,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteE2etestConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteE2etestConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -467,10 +458,11 @@ class AirbyteElasticsearchConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Elasticsearch,
+        config_spec: airbyte.Elasticsearch,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(
             config, AirbyteElasticsearchConnector.definitions_jsonschema
         )
@@ -495,11 +487,11 @@ class AirbyteExasolConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Exasol,
+        config_spec: airbyte.Exasol,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteExasolConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -522,13 +514,12 @@ class AirbyteFireboltConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Firebolt,
+        config_spec: airbyte.Firebolt,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteFireboltConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteFireboltConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -550,13 +541,12 @@ class AirbyteFirestoreConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Firestore,
+        config_spec: airbyte.Firestore,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteFirestoreConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteFirestoreConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -578,11 +568,11 @@ class AirbyteGcsConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Gcs,
+        config_spec: airbyte.Gcs,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteGcsConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -605,13 +595,12 @@ class AirbyteGooglesheetsConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Googlesheets,
+        config_spec: airbyte.Googlesheets,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteGooglesheetsConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteGooglesheetsConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -633,13 +622,12 @@ class AirbyteIcebergConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Iceberg,
+        config_spec: airbyte.Iceberg,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteIcebergConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteIcebergConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -661,11 +649,11 @@ class AirbyteKafkaConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Kafka,
+        config_spec: airbyte.Kafka,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteKafkaConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -688,11 +676,11 @@ class AirbyteKeenConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Keen,
+        config_spec: airbyte.Keen,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteKeenConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -715,13 +703,12 @@ class AirbyteKinesisConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Kinesis,
+        config_spec: airbyte.Kinesis,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteKinesisConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteKinesisConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -743,13 +730,12 @@ class AirbyteLangchainConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Langchain,
+        config_spec: airbyte.Langchain,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteLangchainConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteLangchainConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -771,13 +757,12 @@ class AirbyteLocaljsonConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Localjson,
+        config_spec: airbyte.Localjson,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteLocaljsonConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteLocaljsonConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -799,10 +784,11 @@ class AirbyteMariadbcolumnstoreConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Mariadbcolumnstore,
+        config_spec: airbyte.Mariadbcolumnstore,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(
             config, AirbyteMariadbcolumnstoreConnector.definitions_jsonschema
         )
@@ -827,13 +813,12 @@ class AirbyteMeilisearchConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Meilisearch,
+        config_spec: airbyte.Meilisearch,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteMeilisearchConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteMeilisearchConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -855,11 +840,11 @@ class AirbyteMilvusConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Milvus,
+        config_spec: airbyte.Milvus,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteMilvusConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -882,13 +867,12 @@ class AirbyteMongodbConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Mongodb,
+        config_spec: airbyte.Mongodb,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteMongodbConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteMongodbConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -910,11 +894,11 @@ class AirbyteMqttConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Mqtt,
+        config_spec: airbyte.Mqtt,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteMqttConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -937,11 +921,11 @@ class AirbytMssqlConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Mssql,
+        config_spec: airbyte.Mssql,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbytMssqlConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -964,11 +948,11 @@ class AirbyteMysqlConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Mysql,
+        config_spec: airbyte.Mysql,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteMysqlConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -991,11 +975,11 @@ class AirbyteOracleConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Oracle,
+        config_spec: airbyte.Oracle,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteOracleConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1018,13 +1002,12 @@ class AirbytePineconeConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Pinecone,
+        config_spec: airbyte.Pinecone,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbytePineconeConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbytePineconeConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1046,13 +1029,12 @@ class AirbytePostgresConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Postgres,
+        config_spec: airbyte.Postgres,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbytePostgresConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbytePostgresConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1074,11 +1056,11 @@ class AirbytePubsubConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Pubsub,
+        config_spec: airbyte.Pubsub,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbytePubsubConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1101,11 +1083,11 @@ class AirbytePulsarConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Pulsar,
+        config_spec: airbyte.Pulsar,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbytePulsarConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1128,11 +1110,11 @@ class AirbyteQdrantConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Qdrant,
+        config_spec: airbyte.Qdrant,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteQdrantConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1155,11 +1137,11 @@ class AirbyteR2Connector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.R2,
+        config_spec: airbyte.R2,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteR2Connector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1182,13 +1164,12 @@ class AirbyteRabbitmqConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Rabbitmq,
+        config_spec: airbyte.Rabbitmq,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteRabbitmqConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteRabbitmqConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1210,11 +1191,11 @@ class AirbyteRedisConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Redis,
+        config_spec: airbyte.Redis,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteRedisConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1237,13 +1218,12 @@ class AirbyteRedpandaConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Redpanda,
+        config_spec: airbyte.Redpanda,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteRedpandaConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteRedpandaConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1265,13 +1245,12 @@ class AirbyteRedshiftConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Redshift,
+        config_spec: airbyte.Redshift,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteRedshiftConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteRedshiftConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1293,13 +1272,12 @@ class AirbyteRocksetConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Rockset,
+        config_spec: airbyte.Rockset,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteRocksetConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteRocksetConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1321,11 +1299,11 @@ class AirbyteS3glueConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.S3glue,
+        config_spec: airbyte.S3glue,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteS3glueConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1348,11 +1326,11 @@ class AirbyteS3Connector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.S3,
+        config_spec: airbyte.S3,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteS3Connector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1375,11 +1353,11 @@ class AirbyteScyllaConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Scylla,
+        config_spec: airbyte.Scylla,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteScyllaConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1402,13 +1380,12 @@ class AirbyteSelectdbConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Selectdb,
+        config_spec: airbyte.Selectdb,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteSelectdbConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteSelectdbConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1430,13 +1407,12 @@ class AirbyteSftpjsonConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Sftpjson,
+        config_spec: airbyte.Sftpjson,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteSftpjsonConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteSftpjsonConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1458,13 +1434,12 @@ class AirbyteSnowflakeConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Snowflake,
+        config_spec: airbyte.Snowflake,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteSnowflakeConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteSnowflakeConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1486,11 +1461,11 @@ class AirbyteSqliteConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Sqlite,
+        config_spec: airbyte.Sqlite,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteSqliteConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1513,10 +1488,11 @@ class AirbyteStarburstgalaxyConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Starburstgalaxy,
+        config_spec: airbyte.Starburstgalaxy,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(
             config, AirbyteStarburstgalaxyConnector.definitions_jsonschema
         )
@@ -1541,13 +1517,12 @@ class AirbyteTeradataConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Teradata,
+        config_spec: airbyte.Teradata,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteTeradataConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteTeradataConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1569,11 +1544,11 @@ class AirbyteTidbConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Tidb,
+        config_spec: airbyte.Tidb,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteTidbConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1596,13 +1571,12 @@ class AirbyteTimeplusConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Timeplus,
+        config_spec: airbyte.Timeplus,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteTimeplusConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteTimeplusConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1624,13 +1598,12 @@ class AirbyteTypesenseConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Typesense,
+        config_spec: airbyte.Typesense,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteTypesenseConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteTypesenseConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1652,13 +1625,12 @@ class AirbyteVerticaConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Vertica,
+        config_spec: airbyte.Vertica,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteVerticaConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteVerticaConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1680,13 +1652,12 @@ class AirbyteWeaviateConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Weaviate,
+        config_spec: airbyte.Weaviate,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteWeaviateConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteWeaviateConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1708,11 +1679,11 @@ class AirbyteXataConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Xata,
+        config_spec: airbyte.Xata,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, AirbyteXataConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -1735,13 +1706,12 @@ class AirbyteYugabytedbConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Yugabytedb,
+        config_spec: airbyte.Yugabytedb,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(
-            config, AirbyteYugabytedbConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, AirbyteYugabytedbConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -1763,10 +1733,11 @@ class AirbyteAirbytedevmatecloudConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: airbyte.Airbytedevmatecloud,
+        config_spec: airbyte.Airbytedevmatecloud,
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(
             config, AirbyteAirbytedevmatecloudConnector.definitions_jsonschema
         )

--- a/instill/resources/connector_airbyte.py
+++ b/instill/resources/connector_airbyte.py
@@ -29,16 +29,16 @@ class AirbyteAmazonsqsConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteAmazonsqsConnector.definitions_jsonschema
+            config, AirbyteAmazonsqsConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -57,16 +57,16 @@ class AirbyteAwsdatalakeConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteAwsdatalakeConnector.definitions_jsonschema
+            config, AirbyteAwsdatalakeConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -85,16 +85,16 @@ class AirbyteAzureblobstorageConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteAzureblobstorageConnector.definitions_jsonschema
+            config, AirbyteAzureblobstorageConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -113,16 +113,16 @@ class AirbyteBigqueryConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteBigqueryConnector.definitions_jsonschema
+            config, AirbyteBigqueryConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -141,16 +141,16 @@ class AirbyteCassandraConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteCassandraConnector.definitions_jsonschema
+            config, AirbyteCassandraConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -168,15 +168,16 @@ class AirbyteChromaConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteChromaConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteChromaConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -195,16 +196,16 @@ class AirbyteClickhouseConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteClickhouseConnector.definitions_jsonschema
+            config, AirbyteClickhouseConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -222,15 +223,16 @@ class AirbyteConvexConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteConvexConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteConvexConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -248,15 +250,16 @@ class AirbyteCsvConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteCsvConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteCsvConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -275,16 +278,16 @@ class AirbyteCumulioConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteCumulioConnector.definitions_jsonschema
+            config, AirbyteCumulioConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -303,16 +306,16 @@ class AirbyteDatabendConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteDatabendConnector.definitions_jsonschema
+            config, AirbyteDatabendConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -331,16 +334,16 @@ class AirbyteDatabricksConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteDatabricksConnector.definitions_jsonschema
+            config, AirbyteDatabricksConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -358,15 +361,16 @@ class AirbyteDorisConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteDorisConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteDorisConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -384,15 +388,16 @@ class AirbyteDuckdbConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteDuckdbConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteDuckdbConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -411,16 +416,16 @@ class AirbyteDynamodbConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteDynamodbConnector.definitions_jsonschema
+            config, AirbyteDynamodbConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -439,16 +444,16 @@ class AirbyteE2etestConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteE2etestConnector.definitions_jsonschema
+            config, AirbyteE2etestConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -467,16 +472,16 @@ class AirbyteElasticsearchConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteElasticsearchConnector.definitions_jsonschema
+            config, AirbyteElasticsearchConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -494,15 +499,16 @@ class AirbyteExasolConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteExasolConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteExasolConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -521,16 +527,16 @@ class AirbyteFireboltConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteFireboltConnector.definitions_jsonschema
+            config, AirbyteFireboltConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -549,16 +555,16 @@ class AirbyteFirestoreConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteFirestoreConnector.definitions_jsonschema
+            config, AirbyteFirestoreConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -576,15 +582,16 @@ class AirbyteGcsConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteGcsConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteGcsConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -603,16 +610,16 @@ class AirbyteGooglesheetsConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteGooglesheetsConnector.definitions_jsonschema
+            config, AirbyteGooglesheetsConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -631,16 +638,16 @@ class AirbyteIcebergConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteIcebergConnector.definitions_jsonschema
+            config, AirbyteIcebergConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -658,15 +665,16 @@ class AirbyteKafkaConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteKafkaConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteKafkaConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -684,15 +692,16 @@ class AirbyteKeenConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteKeenConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteKeenConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -711,16 +720,16 @@ class AirbyteKinesisConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteKinesisConnector.definitions_jsonschema
+            config, AirbyteKinesisConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -739,16 +748,16 @@ class AirbyteLangchainConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteLangchainConnector.definitions_jsonschema
+            config, AirbyteLangchainConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -767,16 +776,16 @@ class AirbyteLocaljsonConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteLocaljsonConnector.definitions_jsonschema
+            config, AirbyteLocaljsonConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -795,16 +804,16 @@ class AirbyteMariadbcolumnstoreConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteMariadbcolumnstoreConnector.definitions_jsonschema
+            config, AirbyteMariadbcolumnstoreConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -823,16 +832,16 @@ class AirbyteMeilisearchConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteMeilisearchConnector.definitions_jsonschema
+            config, AirbyteMeilisearchConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -850,15 +859,16 @@ class AirbyteMilvusConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteMilvusConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteMilvusConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -877,16 +887,16 @@ class AirbyteMongodbConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteMongodbConnector.definitions_jsonschema
+            config, AirbyteMongodbConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -904,15 +914,16 @@ class AirbyteMqttConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteMqttConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteMqttConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -930,15 +941,16 @@ class AirbytMssqlConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbytMssqlConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbytMssqlConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -956,15 +968,16 @@ class AirbyteMysqlConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteMysqlConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteMysqlConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -982,15 +995,16 @@ class AirbyteOracleConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteOracleConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteOracleConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1009,16 +1023,16 @@ class AirbytePineconeConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbytePineconeConnector.definitions_jsonschema
+            config, AirbytePineconeConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1037,16 +1051,16 @@ class AirbytePostgresConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbytePostgresConnector.definitions_jsonschema
+            config, AirbytePostgresConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1064,15 +1078,16 @@ class AirbytePubsubConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbytePubsubConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbytePubsubConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1090,15 +1105,16 @@ class AirbytePulsarConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbytePulsarConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbytePulsarConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1116,15 +1132,16 @@ class AirbyteQdrantConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteQdrantConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteQdrantConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1142,15 +1159,16 @@ class AirbyteR2Connector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteR2Connector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteR2Connector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1169,16 +1187,16 @@ class AirbyteRabbitmqConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteRabbitmqConnector.definitions_jsonschema
+            config, AirbyteRabbitmqConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1196,15 +1214,16 @@ class AirbyteRedisConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteRedisConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteRedisConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1223,16 +1242,16 @@ class AirbyteRedpandaConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteRedpandaConnector.definitions_jsonschema
+            config, AirbyteRedpandaConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1251,16 +1270,16 @@ class AirbyteRedshiftConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteRedshiftConnector.definitions_jsonschema
+            config, AirbyteRedshiftConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1279,16 +1298,16 @@ class AirbyteRocksetConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteRocksetConnector.definitions_jsonschema
+            config, AirbyteRocksetConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1306,15 +1325,16 @@ class AirbyteS3glueConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteS3glueConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteS3glueConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1332,15 +1352,16 @@ class AirbyteS3Connector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteS3Connector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteS3Connector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1358,15 +1379,16 @@ class AirbyteScyllaConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteScyllaConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteScyllaConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1385,16 +1407,16 @@ class AirbyteSelectdbConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteSelectdbConnector.definitions_jsonschema
+            config, AirbyteSelectdbConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1413,16 +1435,16 @@ class AirbyteSftpjsonConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteSftpjsonConnector.definitions_jsonschema
+            config, AirbyteSftpjsonConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1441,16 +1463,16 @@ class AirbyteSnowflakeConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteSnowflakeConnector.definitions_jsonschema
+            config, AirbyteSnowflakeConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1468,15 +1490,16 @@ class AirbyteSqliteConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteSqliteConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteSqliteConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1495,16 +1518,16 @@ class AirbyteStarburstgalaxyConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteStarburstgalaxyConnector.definitions_jsonschema
+            config, AirbyteStarburstgalaxyConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1523,16 +1546,16 @@ class AirbyteTeradataConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteTeradataConnector.definitions_jsonschema
+            config, AirbyteTeradataConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1550,15 +1573,16 @@ class AirbyteTidbConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteTidbConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteTidbConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1577,16 +1601,16 @@ class AirbyteTimeplusConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteTimeplusConnector.definitions_jsonschema
+            config, AirbyteTimeplusConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1605,16 +1629,16 @@ class AirbyteTypesenseConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteTypesenseConnector.definitions_jsonschema
+            config, AirbyteTypesenseConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1633,16 +1657,16 @@ class AirbyteVerticaConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteVerticaConnector.definitions_jsonschema
+            config, AirbyteVerticaConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1661,16 +1685,16 @@ class AirbyteWeaviateConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteWeaviateConnector.definitions_jsonschema
+            config, AirbyteWeaviateConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1688,15 +1712,16 @@ class AirbyteXataConnector(Connector):
     ) -> None:
         definition = "connector-definitions/airbyte-destination"
 
-        jsonschema.validate(vars(config), AirbyteXataConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, AirbyteXataConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1715,16 +1740,16 @@ class AirbyteYugabytedbConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteYugabytedbConnector.definitions_jsonschema
+            config, AirbyteYugabytedbConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -1743,14 +1768,14 @@ class AirbyteAirbytedevmatecloudConnector(Connector):
         definition = "connector-definitions/airbyte-destination"
 
         jsonschema.validate(
-            vars(config), AirbyteAirbytedevmatecloudConnector.definitions_jsonschema
+            config, AirbyteAirbytedevmatecloudConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: airbyte_task_write_destination_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)

--- a/instill/resources/connector_blockchain.py
+++ b/instill/resources/connector_blockchain.py
@@ -20,11 +20,11 @@ class NumbersConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: numbers.NumbersProtocolBlockchainConnectorSpec,
+        config_spec: numbers.NumbersProtocolBlockchainConnectorSpec,
     ) -> None:
         definition = "connector-definitions/numbers"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, NumbersConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 

--- a/instill/resources/connector_blockchain.py
+++ b/instill/resources/connector_blockchain.py
@@ -24,13 +24,14 @@ class NumbersConnector(Connector):
     ) -> None:
         definition = "connector-definitions/numbers"
 
-        jsonschema.validate(vars(config), NumbersConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, NumbersConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: numbers_task_commit_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)

--- a/instill/resources/connector_data.py
+++ b/instill/resources/connector_data.py
@@ -48,11 +48,11 @@ class BigQueryConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: bigquery.BigQueryConnectorSpec,
+        config_spec: bigquery.BigQueryConnectorSpec,
     ) -> None:
         definition = "connector-definitions/bigquery"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, BigQueryConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -77,11 +77,11 @@ class PineconeConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: pinecone.PineconeConnectorSpec,
+        config_spec: pinecone.PineconeConnectorSpec,
     ) -> None:
         definition = "connector-definitions/pinecone"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, PineconeConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -109,13 +109,12 @@ class GoogleCloudStorageConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: googlecloudstorage.GoogleCloudStorageConnectorSpec,
+        config_spec: googlecloudstorage.GoogleCloudStorageConnectorSpec,
     ) -> None:
         definition = "connector-definitions/gcs"
 
-        jsonschema.validate(
-            config, GoogleCloudStorageConnector.definitions_jsonschema
-        )
+        config = helper.pop_default_and_to_dict(config_spec)
+        jsonschema.validate(config, GoogleCloudStorageConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
     def create_component(
@@ -139,11 +138,11 @@ class GoogleSearchConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: googlesearch.GoogleSearchConnectorSpec,
+        config_spec: googlesearch.GoogleSearchConnectorSpec,
     ) -> None:
         definition = "connector-definitions/google-search"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, GoogleSearchConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -166,11 +165,11 @@ class RedisConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: redis.RedisConnectorResource,
+        config_spec: redis.RedisConnectorResource,
     ) -> None:
         definition = "connector-definitions/redis"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, RedisConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -197,11 +196,11 @@ class RestAPIConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: restapi.RESTAPIConnectorSpec,
+        config_spec: restapi.RESTAPIConnectorSpec,
     ) -> None:
         definition = "connector-definitions/restapi"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, RestAPIConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 
@@ -233,11 +232,11 @@ class WebsiteConnector(Connector):
         self,
         client: InstillClient,
         name: str,
-        config: website.WebsiteConnectorResource,
+        config_spec: website.WebsiteConnectorResource,
     ) -> None:
         definition = "connector-definitions/website"
 
-        config = helper.pop_default_and_to_dict(config)
+        config = helper.pop_default_and_to_dict(config_spec)
         jsonschema.validate(config, WebsiteConnector.definitions_jsonschema)
         super().__init__(client, name, definition, config)
 

--- a/instill/resources/connector_data.py
+++ b/instill/resources/connector_data.py
@@ -52,15 +52,16 @@ class BigQueryConnector(Connector):
     ) -> None:
         definition = "connector-definitions/bigquery"
 
-        jsonschema.validate(vars(config), BigQueryConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, BigQueryConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: bigquery_task_insert_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -80,8 +81,9 @@ class PineconeConnector(Connector):
     ) -> None:
         definition = "connector-definitions/pinecone"
 
-        jsonschema.validate(vars(config), PineconeConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, PineconeConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
@@ -91,7 +93,7 @@ class PineconeConnector(Connector):
             pinecone_task_upsert_input.Input,
         ],
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -112,16 +114,16 @@ class GoogleCloudStorageConnector(Connector):
         definition = "connector-definitions/gcs"
 
         jsonschema.validate(
-            vars(config), GoogleCloudStorageConnector.definitions_jsonschema
+            config, GoogleCloudStorageConnector.definitions_jsonschema
         )
-        super().__init__(client, name, definition, vars(config))
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: googlecloudstorage_task_upload_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -141,15 +143,16 @@ class GoogleSearchConnector(Connector):
     ) -> None:
         definition = "connector-definitions/google-search"
 
-        jsonschema.validate(vars(config), GoogleSearchConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, GoogleSearchConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: googlesearch_task_search_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -167,8 +170,9 @@ class RedisConnector(Connector):
     ) -> None:
         definition = "connector-definitions/redis"
 
-        jsonschema.validate(vars(config), RedisConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, RedisConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
@@ -179,7 +183,7 @@ class RedisConnector(Connector):
             redis_task_chat_message_write_multi_modal_input.Input,
         ],
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -197,8 +201,9 @@ class RestAPIConnector(Connector):
     ) -> None:
         definition = "connector-definitions/restapi"
 
-        jsonschema.validate(vars(config), RestAPIConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, RestAPIConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
@@ -214,7 +219,7 @@ class RestAPIConnector(Connector):
             restapi_task_put_input.Input,
         ],
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)
 
 
@@ -232,13 +237,14 @@ class WebsiteConnector(Connector):
     ) -> None:
         definition = "connector-definitions/website"
 
-        jsonschema.validate(vars(config), WebsiteConnector.definitions_jsonschema)
-        super().__init__(client, name, definition, vars(config))
+        config = helper.pop_default_and_to_dict(config)
+        jsonschema.validate(config, WebsiteConnector.definitions_jsonschema)
+        super().__init__(client, name, definition, config)
 
     def create_component(
         self,
         name: str,
         inp: website_task_scrape_website_input.Input,
     ) -> Component:
-        config = helper.construct_connector_config(inp)
+        config = helper.construct_component_config(inp)
         return super()._create_component(name, config)

--- a/instill/resources/model.py
+++ b/instill/resources/model.py
@@ -82,7 +82,7 @@ class Model(Resource):
     def get_state(self) -> model_interface.Model.State:
         return self.client.model_service.watch_model(self.resource.id).state
 
-    def deploy(self) -> model_interface.Model:
+    def deploy(self) -> model_interface.Model.State:
         self.client.model_service.deploy_model(self.resource.id)
         state = self.client.model_service.watch_model(model_name=self.resource.id).state
         while state not in (2, 3):
@@ -91,9 +91,9 @@ class Model(Resource):
                 model_name=self.resource.id
             ).state
         self._update()
-        return self._resource
+        return state
 
-    def undeploy(self) -> model_interface.Model:
+    def undeploy(self) -> model_interface.Model.State:
         self.client.model_service.undeploy_model(self.resource.id)
         state = self.client.model_service.watch_model(model_name=self.resource.id).state
         while state not in (1, 3):
@@ -102,7 +102,7 @@ class Model(Resource):
                 model_name=self.resource.id
             ).state
         self._update()
-        return self._resource
+        return state
 
     def delete(self):
         if self.resource is not None:

--- a/instill/resources/operator.py
+++ b/instill/resources/operator.py
@@ -1,9 +1,9 @@
 # pylint: disable=no-member,wrong-import-position
 import instill.protogen.vdp.pipeline.v1beta.pipeline_pb2 as pipeline_pb
 from instill.resources.schema import (
-    helper,
     end_task_end_input,
     end_task_end_metadata,
+    helper,
     start_task_start_metadata,
 )
 
@@ -17,7 +17,7 @@ def create_start_operator(
     start_operator_component.definition_name = "operator-definitions/start"
 
     for key, val in metadata_fields.items():
-        metadata_fields[key] = helper.pop_default_and_to_dict(val)
+        metadata_fields[key] = helper.pop_default_and_to_dict(val)  # type: ignore
     metadata = {"metadata": metadata_fields}
     start_operator_component.configuration.update(metadata)  # type: ignore
 
@@ -34,7 +34,7 @@ def create_end_operator(
     end_operator_component.definition_name = "operator-definitions/end"
 
     for metadata_key, metadata_val in metadata_fields.items():
-        metadata_fields[metadata_key] = helper.pop_default_and_to_dict(metadata_val)
+        metadata_fields[metadata_key] = helper.pop_default_and_to_dict(metadata_val)  # type: ignore
     inp = {"input": inp_fields}
     metadata = {"metadata": metadata_fields}
     end_operator_component.configuration.update(inp)

--- a/instill/resources/operator.py
+++ b/instill/resources/operator.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-member,wrong-import-position
 import instill.protogen.vdp.pipeline.v1beta.pipeline_pb2 as pipeline_pb
 from instill.resources.schema import (
+    helper,
     end_task_end_input,
     end_task_end_metadata,
     start_task_start_metadata,
@@ -8,25 +9,34 @@ from instill.resources.schema import (
 
 
 def create_start_operator(
-    metadata: start_task_start_metadata.Model,
+    metadata_fields: start_task_start_metadata.Model,
 ) -> pipeline_pb.Component:
     start_operator_component = pipeline_pb.Component()
     start_operator_component.id = "start"
     start_operator_component.resource_name = ""
     start_operator_component.definition_name = "operator-definitions/start"
+
+    for key, val in metadata_fields.items():
+        metadata_fields[key] = helper.pop_default_and_to_dict(val)
+    metadata = {"metadata": metadata_fields}
     start_operator_component.configuration.update(metadata)  # type: ignore
 
     return start_operator_component
 
 
 def create_end_operator(
-    inp: end_task_end_input.Input,
-    metadata: end_task_end_metadata.Model,
+    inp_fields: end_task_end_input.Input,
+    metadata_fields: end_task_end_metadata.Model,
 ) -> pipeline_pb.Component:
     end_operator_component = pipeline_pb.Component()
     end_operator_component.id = "end"
     end_operator_component.resource_name = ""
     end_operator_component.definition_name = "operator-definitions/end"
+
+    for metadata_key, metadata_val in metadata_fields.items():
+        metadata_fields[metadata_key] = helper.pop_default_and_to_dict(metadata_val)
+    inp = {"input": inp_fields}
+    metadata = {"metadata": metadata_fields}
     end_operator_component.configuration.update(inp)
     end_operator_component.configuration.update(metadata)  # type: ignore
 

--- a/instill/resources/schema/helper.py
+++ b/instill/resources/schema/helper.py
@@ -1,5 +1,4 @@
 import re
-
 from dataclasses import fields, is_dataclass
 
 

--- a/instill/resources/schema/helper.py
+++ b/instill/resources/schema/helper.py
@@ -1,33 +1,49 @@
 import re
 
+from dataclasses import fields, is_dataclass
 
-def populate_default_value(dataclass):
-    for field in dataclass.__dataclass_fields__.values():
-        if field.default is None and getattr(dataclass, field.name) is None:
+
+def populate_default_value(dc):
+    for field in fields(dc):
+        if field.default is None and getattr(dc, field.name) is None:
             list_pattern = re.compile(r"^Optional\[List")
             other_optional_pattern = re.compile(r"^Optional\[")
             if field.type == "Optional[bool]":
-                setattr(dataclass, field.name, False)
+                setattr(dc, field.name, False)
             elif field.type == "Optional[str]":
-                setattr(dataclass, field.name, "")
+                setattr(dc, field.name, "")
             elif field.type == "Optional[int]":
-                setattr(dataclass, field.name, 0)
+                setattr(dc, field.name, 0)
             elif field.type == "Optional[float]":
-                setattr(dataclass, field.name, 0.0)
+                setattr(dc, field.name, 0.0)
             elif list_pattern.match(field.type):
-                setattr(dataclass, field.name, [])
+                setattr(dc, field.name, [])
             elif other_optional_pattern.match(field.type):
-                setattr(dataclass, field.name, {})
+                setattr(dc, field.name, {})
 
-    return dataclass
+    return dc
 
 
-def construct_connector_config(inp):
+def pop_default_and_to_dict(dc) -> dict:
+    if isinstance(dc, dict):
+        return dc
+
+    output_dict = {}
+    for field in fields(dc):
+        field_val = getattr(dc, field.name)
+        if field_val is not None:
+            if is_dataclass(field_val):
+                field_val = pop_default_and_to_dict(field_val)
+            output_dict[field.name] = field_val
+    return output_dict
+
+
+def construct_component_config(inp):
     task_name = str(inp.__class__).split(".")[3]
     prefix = task_name.split("_")[0] + "_"
     suffix = "_" + task_name.split("_")[-1]
     config = {
-        "input": vars(inp),
+        "input": pop_default_and_to_dict(inp),
         "task": remove_prefix_and_suffix(
             task_name,
             prefix,


### PR DESCRIPTION
Because

- Optional field should be discarded from `dict` if no value is deliberately set

This commit

- pop optional values with `None` instead of populating it with zero value
- adopt `dataclass` to `dict` transform inside each resource class instead of expose it to user
- update `Readme` and notebook
