### PR TITLE
feat(resources): support recipe update in pipeline resource

### DIFF
--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -203,7 +203,8 @@ class PipelineClient(Client):
             return RequestFactory(
                 method=self.hosts[self.instance].async_client.GetUserPipeline,
                 request=pipeline_interface.GetUserPipelineRequest(
-                    name=f"{self.target_namespace}/pipelines/{name}"
+                    name=f"{self.target_namespace}/pipelines/{name}",
+                    view=pipeline_interface.Pipeline.VIEW_FULL,
                 ),
                 metadata=self.hosts[self.instance].metadata,
             ).send_async()
@@ -211,7 +212,8 @@ class PipelineClient(Client):
         return RequestFactory(
             method=self.hosts[self.instance].client.GetUserPipeline,
             request=pipeline_interface.GetUserPipelineRequest(
-                name=f"{self.target_namespace}/pipelines/{name}"
+                name=f"{self.target_namespace}/pipelines/{name}",
+                view=pipeline_interface.Pipeline.VIEW_FULL,
             ),
             metadata=self.hosts[self.instance].metadata,
         ).send_sync()

--- a/instill/resources/pipeline.py
+++ b/instill/resources/pipeline.py
@@ -3,6 +3,7 @@ from typing import Tuple, Union
 
 import grpc
 from google.longrunning import operations_pb2
+from google.protobuf.field_mask_pb2 import FieldMask
 
 import instill.protogen.vdp.pipeline.v1beta.pipeline_pb2 as pipeline_interface
 from instill.clients import InstillClient
@@ -66,8 +67,16 @@ class Pipeline(Resource):
             self.resource.id, task_inputs
         ).operation
 
-    def get_recipe(self) -> str:
+    def get_recipe(self) -> pipeline_interface.Recipe:
         return self.resource.recipe
+
+    def update_recipe(self, recipe: pipeline_interface.Recipe):
+        pipeline = self.resource
+        pipeline.recipe.CopyFrom(recipe)
+        self.client.pipeline_service.update_pipeline(
+            pipeline, FieldMask(paths=["recipe"])
+        )
+        self._update()
 
     def validate_pipeline(self) -> bool:
         try:


### PR DESCRIPTION
Because

- currently we dont support updating recipe in pipeline resource object

This commit

- support recipe update in pipeline resource
