### PR TITLE
feat(ray): determine vram usage by file size

### DIFF
--- a/instill/helpers/ray_config.py
+++ b/instill/helpers/ray_config.py
@@ -6,13 +6,13 @@ from ray import serve
 from ray.serve import Deployment
 from ray.serve import deployment as ray_deployment
 
-from instill.helpers.utils import get_dir_size
 from instill.helpers.const import (
     DEFAULT_AUTOSCALING_CONFIG,
     DEFAULT_MAX_CONCURRENT_QUERIES,
     DEFAULT_RAY_ACTOR_OPRTIONS,
     DEFAULT_RUNTIME_ENV,
 )
+from instill.helpers.utils import get_dir_size
 
 
 class InstillDeployable:

--- a/instill/helpers/utils.py
+++ b/instill/helpers/utils.py
@@ -1,0 +1,12 @@
+import os
+
+
+def get_dir_size(path):
+    total = 0
+    with os.scandir(path) as it:
+        for entry in it:
+            if entry.is_file():
+                total += entry.stat().st_size
+            elif entry.is_dir():
+                total += get_dir_size(entry.path)
+    return total


### PR DESCRIPTION
Because

- we want to dynamically adjust the `num_of_gpus` value for each model

This commit

- determine vram usage by file size
