### PR TITLE
fix(ray): update default resources allocation for test

### DIFF
--- a/instill/helpers/ray_config.py
+++ b/instill/helpers/ray_config.py
@@ -33,10 +33,10 @@ class InstillDeployable:
         # params
         self.model_weight_or_folder_name: str = model_weight_or_folder_name
         if use_gpu:
-            self._update_num_cpus(1)
-            self._update_num_gpus(0.25)
+            self._update_num_cpus(0.25)
+            self._update_num_gpus(0.2)
         else:
-            self._update_num_cpus(2)
+            self._update_num_cpus(0.25)
 
     def _update_num_cpus(self, num_cpus: float):
         if self._deployment.ray_actor_options is not None:


### PR DESCRIPTION
Because

- GA runner does not have enough resource to run ray model tests

This commit

- lower resource allocation
