### PR TITLE
fix(ray): show build logs and add pip timeout

### DIFF
--- a/instill/helpers/Dockerfile
+++ b/instill/helpers/Dockerfile
@@ -8,7 +8,7 @@ RUN sudo apt-get update && sudo apt-get install curl -y
 
 ARG PACKAGES
 RUN for package in ${PACKAGES}; do \
-    pip install $package; \
+    pip install --default-timeout=1000 --no-cache-dir $package; \
     done;
 
 WORKDIR /home/ray

--- a/instill/helpers/build.py
+++ b/instill/helpers/build.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         packages_str += f"instill-sdk=={instill_version}"
 
         Logger.i("[Instill Builder] Building model image...")
-        img, _ = client.images.build(
+        img, logs = client.images.build(
             path="./",
             rm=True,
             nocache=True,
@@ -56,10 +56,12 @@ if __name__ == "__main__":
             quiet=False,
         )
         Logger.i(f"[Instill Builder] {registry}/{repo}:{tag} built")
+        for line in logs:
+            print(*line.values())
         img.tag(f"{registry}/{repo}", tag)
-        client.images.remove(f"{repo}:{tag}")
         Logger.i("[Instill Builder] Pushing model image...")
         client.images.push(f"{registry}/{repo}", tag=tag)
+        client.images.remove(f"{repo}:{tag}")
         Logger.i(f"[Instill Builder] {registry}/{repo}:{tag} pushed")
     except Exception as e:
         Logger.e("[Instill Builder] Build failed")


### PR DESCRIPTION
Because

- It is hard to know what went wrong without build logs
- pip install tends to timeout for large packages installation

This commit

- print build logs
- add default timeout for pip package installation
