### PR TITLE
fix(ray): add missing cuda suffix arg

### DIFF
--- a/instill/helpers/build.py
+++ b/instill/helpers/build.py
@@ -50,6 +50,7 @@ if __name__ == "__main__":
             buildargs={
                 "RAY_VERSION": ray_version,
                 "PYTHON_VERSION": python_version,
+                "CUDA_SUFFIX": cuda_suffix,
                 "PACKAGES": packages_str,
             },
             quiet=False,


### PR DESCRIPTION
Because

- Missing `CUDA_SUFFIX` ARG will cause model container to lose GPU capability

This commit

- add missing cuda suffix arg
