### PR TITLE
fix(ray): update dockerfile package string delimiter

### DIFF
--- a/instill/helpers/Dockerfile
+++ b/instill/helpers/Dockerfile
@@ -5,10 +5,11 @@ ARG CUDA_SUFFIX
 FROM rayproject/ray:${RAY_VERSION}-py${PYTHON_VERSION}${CUDA_SUFFIX}
 
 RUN sudo apt-get update && sudo apt-get install curl -y
+RUN pip install --upgrade pip setuptools wheel
 
 ARG PACKAGES
-RUN for package in ${PACKAGES}; do \
-    pip install --default-timeout=1000 --no-cache-dir $package; \
+RUN IFS=",";for package in $PACKAGES; do \
+    pip install --default-timeout=1000 --no-cache-dir "$package"; \
     done;
 
 WORKDIR /home/ray/model

--- a/instill/helpers/build.py
+++ b/instill/helpers/build.py
@@ -49,9 +49,9 @@ if __name__ == "__main__":
         packages_str = ""
         if not build["python_packages"] is None:
             for p in build["python_packages"]:
-                packages_str += p + " "
+                packages_str += f"{p},"
         for p in DEFAULT_DEPENDENCIES:
-            packages_str += p + " "
+            packages_str += f"{p},"
         packages_str += f"instill-sdk=={instill_version}"
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/samples/tinyllama-cpu/instill.yaml
+++ b/samples/tinyllama-cpu/instill.yaml
@@ -2,7 +2,7 @@ build:
   gpu: false
   python_version: "3.11"  # support only 3.11
   python_packages:
-    - '"torch==2.2.1 --index-url https://download.pytorch.org/whl/cpu"'
+    - torch==2.2.1 --index-url https://download.pytorch.org/whl/cpu
     - transformers==4.36.2
     - accelerate==0.25.0
 repo: admin/tinyllama-cpu  # make sure the format is {user-id}/{model-id} and the

--- a/samples/yolov7-cpu/instill.yaml
+++ b/samples/yolov7-cpu/instill.yaml
@@ -2,8 +2,8 @@ build:
   gpu: false
   python_version: "3.11"  # support only 3.11
   python_packages:
-    - '"torch==2.2.1 --index-url https://download.pytorch.org/whl/cpu"'
-    - '"torchvision==0.17.1 --index-url https://download.pytorch.org/whl/cpu"'
+    - torch==2.2.1 --index-url https://download.pytorch.org/whl/cpu
+    - torchvision==0.17.1 --index-url https://download.pytorch.org/whl/cpu
     - opencv-contrib-python-headless==4.8.1.78
     - onnxruntime==1.17.1
 repo: admin/yolov7-cpu  # make sure the format is {user-id}/{model-id} and the


### PR DESCRIPTION
Because

- Package string with whitespaces is interpreted as separate string

This commit

- fix `pip install` not correctly install packages
