### PR TITLE
fix(ray): fix etrypoint module not found

### DIFF
--- a/instill/helpers/Dockerfile
+++ b/instill/helpers/Dockerfile
@@ -11,5 +11,5 @@ RUN for package in ${PACKAGES}; do \
     pip install --default-timeout=1000 --no-cache-dir $package; \
     done;
 
-WORKDIR /home/ray/model
+WORKDIR /home/ray
 COPY . .

--- a/instill/helpers/utils.py
+++ b/instill/helpers/utils.py
@@ -1,12 +1,32 @@
 import os
 
+IGNORE_FILES = {
+    ".bash_logout",
+    ".bashrc",
+    ".profile",
+    ".sudo_as_admin_successful",
+    "pip-freeze.txt",
+    "requirements_compiled.txt",
+}
+
+IGNORE_FOLDERS = {
+    ".cache",
+    ".conda",
+    ".whl",
+    "anaconda3",
+}
+
 
 def get_dir_size(path):
     total = 0
     with os.scandir(path) as it:
         for entry in it:
             if entry.is_file():
+                if entry.name in IGNORE_FILES:
+                    continue
                 total += entry.stat().st_size
             elif entry.is_dir():
+                if entry.name in IGNORE_FOLDERS:
+                    continue
                 total += get_dir_size(entry.path)
     return total


### PR DESCRIPTION
Because

- `model.py` not in the user root dir and will cause
```
File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/utils.py", line 1194, in import_attr
    return getattr(module, attr_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'model' has no attribute 'entrypoint'
```

This commit

- move the model files back into user root
- update scope of model file size calculation
