### PR TITLE
fix(ray): support target platform for image building

### DIFF
--- a/instill/helpers/build.py
+++ b/instill/helpers/build.py
@@ -1,6 +1,7 @@
 import argparse
 import hashlib
 import os
+import platform
 import shutil
 import tempfile
 
@@ -14,12 +15,22 @@ from instill.utils.logger import Logger
 
 if __name__ == "__main__":
     Logger.i("[Instill Builder] Setup docker...")
-
+    if platform.machine() in ("i386", "AMD64", "x86_64"):
+        default_platform = "amd64"
+    else:
+        default_platform = platform.machine()
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--no-cache",
         help="build the image without cache",
         action="store_true",
+        required=False,
+    )
+    parser.add_argument(
+        "--target-arch",
+        help="target platform architecture for the model image, default to host",
+        default=default_platform,
+        choices=["arm64", "amd64"],
         required=False,
     )
 
@@ -66,6 +77,7 @@ if __name__ == "__main__":
                 rm=True,
                 pull=True,
                 nocache=args.no_cache,
+                platform=f"linux/{args.target_arch}",
                 tag=f"{repo}:{tag}",
                 buildargs={
                     "RAY_VERSION": ray_version,


### PR DESCRIPTION
Because

- Image built with `build` module may have mismatch target platform

This commit

- support target platform for image building
