### PR TITLE
fix(ray): fix missing default resource value

### DIFF
--- a/instill/helpers/ray_config.py
+++ b/instill/helpers/ray_config.py
@@ -40,6 +40,8 @@ class InstillDeployable:
         num_of_cpus = os.getenv(ENV_NUM_OF_CPUS)
         if num_of_cpus is not None and num_of_cpus != "":
             self.update_num_cpus(float(num_of_cpus))
+        else:
+            self.update_num_cpus(1)
 
         memory = os.getenv(ENV_MEMORY)
         if memory is not None and memory != "":
@@ -48,10 +50,14 @@ class InstillDeployable:
         num_of_min_replicas = os.getenv(ENV_NUM_OF_MIN_REPLICAS)
         if num_of_min_replicas is not None and num_of_min_replicas != "":
             self.update_min_replicas(int(num_of_min_replicas))
+        else:
+            self.update_min_replicas(0)
 
         num_of_max_replicas = os.getenv(ENV_NUM_OF_MAX_REPLICAS)
         if num_of_max_replicas is not None and num_of_max_replicas != "":
             self.update_max_replicas(int(num_of_max_replicas))
+        else:
+            self.update_max_replicas(1)
 
         vram = os.getenv(ENV_TOTAL_VRAM)
         if vram is not None and vram != "":


### PR DESCRIPTION
Because

- Missing default value might cause to the model to become unschedulable

This commit

- add default resource value if not presented
