### PR TITLE
fix(dockerfile): avoid build hang at ARG statement

### DIFF
--- a/instill/helpers/Dockerfile
+++ b/instill/helpers/Dockerfile
@@ -5,9 +5,10 @@ ARG TARGET_ARCH_SUFFIX
 
 FROM rayproject/ray:${RAY_VERSION}-py${PYTHON_VERSION}${CUDA_SUFFIX}${TARGET_ARCH_SUFFIX}
 
+ARG PACKAGES
+
 RUN sudo apt-get update && sudo apt-get install curl -y
 
-ARG PACKAGES
 RUN for package in ${PACKAGES}; do \
     pip install --default-timeout=1000 --no-cache-dir $package; \
     done;


### PR DESCRIPTION
Because

- We are seeing occasional hang at `ARG` statement and change the statement order seems to solve it for now, need to keep an eye on it.

This commit

- change `ARG` statement order

resolves INS-4015
