### PR TITLE
feat(ray): implement standalone executable and optional system packages

### DIFF
--- a/instill/helpers/Dockerfile
+++ b/instill/helpers/Dockerfile
@@ -7,6 +7,11 @@ FROM rayproject/ray:${RAY_VERSION}-py${PYTHON_VERSION}${CUDA_SUFFIX}${TARGET_ARC
 
 RUN sudo apt-get update && sudo apt-get install curl -y
 
+ARG SYSTEM_PACKAGES
+RUN for package in ${SYSTEM_PACKAGES}; do \
+    sudo apt-get install $package; \
+    done;
+
 ARG PACKAGES
 RUN for package in ${PACKAGES}; do \
     pip install --default-timeout=1000 --no-cache-dir $package; \

--- a/instill/helpers/errors.py
+++ b/instill/helpers/errors.py
@@ -6,3 +6,13 @@ class ModelPathException(Exception):
 class ModelVramException(Exception):
     def __str__(self) -> str:
         return "model projected vram usage is more than the GPU can handle"
+
+
+class ModelConfigException(Exception):
+    def __init__(self, field):
+        self.field = field
+
+    def __str__(
+        self,
+    ) -> str:
+        return f"model config file `instill.yaml` is missing {self.field} field"

--- a/instill/helpers/push.py
+++ b/instill/helpers/push.py
@@ -5,9 +5,8 @@ import yaml
 
 from instill.utils.logger import Logger
 
-if __name__ == "__main__":
-    Logger.i("[Instill Builder] Setup docker...")
 
+def push_image():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-u",
@@ -15,6 +14,12 @@ if __name__ == "__main__":
         help="image registry url, in the format of host:port, default to docker.io",
         default="docker.io",
         required=False,
+    )
+    parser.add_argument(
+        "-t",
+        "--tag",
+        help="tag for the model image",
+        required=True,
     )
 
     try:
@@ -27,18 +32,22 @@ if __name__ == "__main__":
 
         registry = args.url
         repo = config["repo"]
-        tag = config["tag"]
 
         subprocess.run(
-            ["docker", "tag", f"{repo}:{tag}", f"{registry}/{repo}:{tag}"], check=True
+            ["docker", "tag", f"{repo}:{args.tag}", f"{registry}/{repo}:{args.tag}"],
+            check=True,
         )
         Logger.i("[Instill Builder] Pushing model image...")
-        subprocess.run(["docker", "push", f"{registry}/{repo}:{tag}"], check=True)
-        Logger.i(f"[Instill Builder] {registry}/{repo}:{tag} pushed")
-    except subprocess.CalledProcessError as e:
+        subprocess.run(["docker", "push", f"{registry}/{repo}:{args.tag}"], check=True)
+        Logger.i(f"[Instill Builder] {registry}/{repo}:{args.tag} pushed")
+    except subprocess.CalledProcessError:
         Logger.e("[Instill Builder] Push failed")
     except Exception as e:
         Logger.e("[Instill Builder] Prepare failed")
         Logger.e(e)
     finally:
         Logger.i("[Instill Builder] Done")
+
+
+if __name__ == "__main__":
+    push_image()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ homepage = "https://pypi.org/project/instill-sdk"
 documentation = "https://instill-sdk.readthedocs.io"
 repository = "https://github.com/instill-ai/python-sdk"
 
+maintainers = ["Heiru Wu <heiru.wu@instill.tech>"]
+
 keywords = []
 classifiers = [
   "Development Status :: 1 - Planning",
@@ -37,7 +39,7 @@ googleapis-common-protos = "^1.60.0"
 protoc-gen-openapiv2 = "^0.0.1"
 pydantic = ">=1.10.13"
 pillow = "^10.1.0"
-ray = {version = "2.9.3", extras = ["serve"]}
+ray = { version = "2.9.3", extras = ["serve"] }
 jsonschema = "^4.20.0"
 
 [tool.poetry.dev-dependencies]
@@ -84,8 +86,8 @@ jsonref = "^1.1.0"
 twine = "^4.0.2"
 
 [tool.poetry.scripts]
-
-# python-sdk = "instill.cli:main"
+instill_build = "instill.helpers.build:build_image"
+instill_push = "instill.helpers.push:push_image"
 
 [tool.black]
 
@@ -118,9 +120,7 @@ profile = "black"
 skip_glob = ["**/protogen/*", "**/protobufs/*"]
 
 [tool.mypy]
-exclude = [
-    'instill/resources/schema',
-]
+exclude = ['instill/resources/schema']
 ignore_missing_imports = true
 no_implicit_optional = true
 check_untyped_defs = true


### PR DESCRIPTION
Because

- user may want to install system packages in custom models
- to execute build/push module, user has to know the exact import path
- build image with different tag involves editing the config file, which is not ideal

This commit

- build and distribute build/push modules as standalone executables
- support installing optional system packages in custom model image
- make tag as input args instead of being as a field inside config file

Resolves INS-4377
Resolves INS-4379