### PR TITLE
chore(deps): bump doc dep version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.3.1 ; python_version >= "3.8" and python_version < "3.13"
 pygments==2.17.2 ; python_version >= "3.8" and python_version < "3.13"
-jinja2==3.1.2 ; python_version >= "3.8" and python_version < "3.13"
+jinja2==3.1.3 ; python_version >= "3.8" and python_version < "3.13"


### PR DESCRIPTION
Because

- avoid package vulnerability 

This commit

- bump `jinja` version
