### PR TITLE
fix(clients): fix message length

### DIFF
--- a/instill/clients/instance.py
+++ b/instill/clients/instance.py
@@ -17,10 +17,8 @@ class InstillInstance:
         self.metadata: Union[str, tuple] = ""
 
         channel_options = (
-            [
-                ("grpc.max_send_message_length", 10 * MB),
-                ("grpc.max_receive_message_length", 10 * MB),
-            ],
+            ("grpc.max_send_message_length", 10 * MB),
+            ("grpc.max_receive_message_length", 10 * MB),
         )
 
         if not secure:


### PR DESCRIPTION
Because

- Response with large payload will result in
```
2024-05-09 05:24:41,357.357 WARNING  StatusCode.RESOURCE_EXHAUSTED
2024-05-09 05:24:41,357.357 WARNING  Received message larger than max (5666203 vs. 4194304)
```

This commit

- add max send/receive message length option
