### PR TITLE
chore(clients): update message length to 32MB

### DIFF
--- a/instill/clients/instance.py
+++ b/instill/clients/instance.py
@@ -17,8 +17,8 @@ class InstillInstance:
         self.metadata: Union[str, tuple] = ""
 
         channel_options = (
-            ("grpc.max_send_message_length", 10 * MB),
-            ("grpc.max_receive_message_length", 10 * MB),
+            ("grpc.max_send_message_length", 32 * MB),
+            ("grpc.max_receive_message_length", 32 * MB),
         )
 
         if not secure:


### PR DESCRIPTION
Because

- the original 10MB size limit is not enough.

This commit

- increase size limit to 32MB.
