### PR TITLE
chore(deps): update upstream deprecated configs

### DIFF
--- a/instill/helpers/const.py
+++ b/instill/helpers/const.py
@@ -85,15 +85,15 @@ DEFAULT_RAY_ACTOR_OPTIONS = {
     "num_cpus": 0,
 }
 DEFAULT_AUTOSCALING_CONFIG = {
-    "target_num_ongoing_requests_per_replica": 2,
+    "target_ongoing_requests": 2,
     "initial_replicas": 1,
     "min_replicas": 0,
-    "max_replicas": 10,
+    "max_replicas": 1,
     "upscale_delay_s": 180,
-    "downscale_delay_s": 120,
+    "downscale_delay_s": 360,
     "smoothing_factor": 1.0,
-    "upscale_smoothing_factor": 0.8,
-    "downscale_smoothing_factor": 0.8,
+    "upscaling_factor": 0.8,
+    "downscaling_factor": 0.8,
     "metrics_interval_s": 2,
     "look_back_period_s": 4,
 }
@@ -102,7 +102,8 @@ DEFAULT_RUNTIME_ENV = {
         "PYTHONPATH": os.getcwd(),
     },
 }
-DEFAULT_MAX_CONCURRENT_QUERIES = 5
+DEFAULT_MAX_ONGOING_REQUESTS = 5
+DEFAULT_MAX_QUEUED_REQUESTS = 10
 
 RAM_MINIMUM_RESERVE = 1  # GB
 RAM_UPSCALE_FACTOR = 1.25

--- a/instill/helpers/ray_config.py
+++ b/instill/helpers/ray_config.py
@@ -7,7 +7,8 @@ from ray.serve import deployment as ray_deployment
 
 from instill.helpers.const import (
     DEFAULT_AUTOSCALING_CONFIG,
-    DEFAULT_MAX_CONCURRENT_QUERIES,
+    DEFAULT_MAX_ONGOING_REQUESTS,
+    DEFAULT_MAX_QUEUED_REQUESTS,
     DEFAULT_RAY_ACTOR_OPTIONS,
     ENV_MEMORY,
     ENV_NUM_OF_CPUS,
@@ -174,5 +175,6 @@ def instill_deployment(
         _func_or_class=_func_or_class,
         ray_actor_options=DEFAULT_RAY_ACTOR_OPTIONS,
         autoscaling_config=DEFAULT_AUTOSCALING_CONFIG,
-        max_concurrent_queries=DEFAULT_MAX_CONCURRENT_QUERIES,
+        max_ongoing_requests=DEFAULT_MAX_ONGOING_REQUESTS,
+        max_queued_requests=DEFAULT_MAX_QUEUED_REQUESTS,
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -211,8 +211,8 @@ files = [
 lazy-object-proxy = ">=1.4.0"
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
 ]
 
 [[package]]
@@ -720,9 +720,9 @@ isort = ">=4.3.21,<6.0"
 jinja2 = ">=2.10.1,<4.0"
 packaging = "*"
 pydantic = [
-    {version = ">=1.5.1,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version < \"3.10\""},
     {version = ">=1.10.0,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.12\" and python_version < \"4.0\""},
     {version = ">=1.10.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.5.1,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version < \"3.10\""},
     {version = ">=1.9.0,<2.4.0 || >2.4.0,<3.0", extras = ["email"], markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
 ]
 pyyaml = ">=6.0.1"
@@ -2962,8 +2962,8 @@ files = [
 astroid = ">=2.12.13,<=2.14.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
 ]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
@@ -3349,8 +3349,8 @@ fastapi = {version = "*", optional = true, markers = "extra == \"serve\""}
 filelock = "*"
 frozenlist = "*"
 grpcio = [
-    {version = ">=1.32.0", optional = true, markers = "python_version < \"3.10\" and extra == \"serve\""},
     {version = ">=1.42.0", optional = true, markers = "python_version >= \"3.10\" and extra == \"serve\""},
+    {version = ">=1.32.0", optional = true, markers = "python_version < \"3.10\" and extra == \"serve\""},
 ]
 jsonschema = "*"
 memray = {version = "*", optional = true, markers = "sys_platform != \"win32\" and extra == \"serve\""}


### PR DESCRIPTION
Because

- `Ray` had deprecated and renamed some config fields for application

This commit

- update deprecated configs
