### PR TITLE
chore(dockerfile): exclude config file from build process

### DIFF
--- a/instill/helpers/.dockerignore
+++ b/instill/helpers/.dockerignore
@@ -15,3 +15,6 @@ __pycache__
 
 # Exclude Python virtual environment
 /venv
+
+# Exclude model config file
+instill.yaml

--- a/instill/helpers/Dockerfile
+++ b/instill/helpers/Dockerfile
@@ -19,6 +19,5 @@ RUN for package in ${PACKAGES}; do \
     done;
 
 WORKDIR /home/ray
-COPY --link --exclude=instill.yaml --exclude=model.py . .
+COPY --link --exclude=model.py . .
 COPY model.py model.py
-COPY instill.yaml instill.yaml


### PR DESCRIPTION
Because

- Avoid producing different image when updating config file

This commit

- exclude config file from build process
