### PR TITLE
chore(poetry): update build/push command alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,8 @@ jsonref = "^1.1.0"
 twine = "^4.0.2"
 
 [tool.poetry.scripts]
-instill_build = "instill.helpers.build:build_image"
-instill_push = "instill.helpers.push:push_image"
+instill-build = "instill.helpers.build:build_image"
+instill-push = "instill.helpers.push:push_image"
 
 [tool.black]
 


### PR DESCRIPTION
Because

- In command line underscore is quite uncommon

This commit

- use hyphen instead of underscore in build/push command alias
