### PR TITLE
chore(clients,resources): fix out dated api spec and methods

### DIFF
--- a/instill/clients/model.py
+++ b/instill/clients/model.py
@@ -125,29 +125,6 @@ class ModelClient(Client):
         ).send_sync()
 
     @grpc_handler
-    def create_model_local(
-        self,
-        model_name: str,
-        model_description: str,
-        model_path: str,
-    ) -> model_interface.CreateUserModelBinaryFileUploadResponse:
-        model = model_interface.Model()
-        model.id = model_name
-        model.description = model_description
-        model.model_definition = "model-definitions/local"
-
-        with open(model_path, "rb") as f:
-            data = f.read()
-            req = model_interface.CreateUserModelBinaryFileUploadRequest(
-                parent=self.namespace, model=model, content=data
-            )
-        return RequestFactory(
-            method=self.hosts[self.instance].client.CreateUserModelBinaryFileUpload,
-            request=req,
-            metadata=self.hosts[self.instance].metadata,
-        ).send_stream()
-
-    @grpc_handler
     def create_model(
         self,
         name: str,
@@ -172,52 +149,6 @@ class ModelClient(Client):
             method=self.hosts[self.instance].client.CreateUserModel,
             request=model_interface.CreateUserModelRequest(
                 model=model, parent=self.namespace
-            ),
-            metadata=self.hosts[self.instance].metadata,
-        ).send_sync()
-
-    @grpc_handler
-    def deploy_model(
-        self,
-        model_name: str,
-        async_enabled: bool = False,
-    ) -> model_interface.DeployUserModelResponse:
-        if async_enabled:
-            return RequestFactory(
-                method=self.hosts[self.instance].async_client.DeployUserModel,
-                request=model_interface.DeployUserModelRequest(
-                    name=f"{self.namespace}/models/{model_name}"
-                ),
-                metadata=self.hosts[self.instance].metadata,
-            ).send_async()
-
-        return RequestFactory(
-            method=self.hosts[self.instance].client.DeployUserModel,
-            request=model_interface.DeployUserModelRequest(
-                name=f"{self.namespace}/models/{model_name}"
-            ),
-            metadata=self.hosts[self.instance].metadata,
-        ).send_sync()
-
-    @grpc_handler
-    def undeploy_model(
-        self,
-        model_name: str,
-        async_enabled: bool = False,
-    ) -> model_interface.UndeployUserModelResponse:
-        if async_enabled:
-            return RequestFactory(
-                method=self.hosts[self.instance].async_client.UndeployUserModel,
-                request=model_interface.UndeployUserModelRequest(
-                    name=f"{self.namespace}/models/{model_name}"
-                ),
-                metadata=self.hosts[self.instance].metadata,
-            ).send_async()
-
-        return RequestFactory(
-            method=self.hosts[self.instance].client.UndeployUserModel,
-            request=model_interface.UndeployUserModelRequest(
-                name=f"{self.namespace}/models/{model_name}"
             ),
             metadata=self.hosts[self.instance].metadata,
         ).send_sync()

--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -877,19 +877,19 @@ class PipelineClient(Client):
         self,
         name: str,
         async_enabled: bool = False,
-    ) -> pipeline_interface.GetUserPipelineResponse:
+    ) -> pipeline_interface.GetOrganizationPipelineResponse:
         if async_enabled:
             return RequestFactory(
-                method=self.hosts[self.instance].async_client.GetUserPipeline,
-                request=pipeline_interface.GetUserPipelineRequest(
+                method=self.hosts[self.instance].async_client.GetOrganizationPipeline,
+                request=pipeline_interface.GetOrganizationPipelineRequest(
                     name=f"{self.target_namespace}/pipelines/{name}"
                 ),
                 metadata=self.hosts[self.instance].metadata,
             ).send_async()
 
         return RequestFactory(
-            method=self.hosts[self.instance].client.GetUserPipeline,
-            request=pipeline_interface.GetUserPipelineRequest(
+            method=self.hosts[self.instance].client.GetOrganizationPipeline,
+            request=pipeline_interface.GetOrganizationPipelineRequest(
                 name=f"{self.target_namespace}/pipelines/{name}"
             ),
             metadata=self.hosts[self.instance].metadata,

--- a/instill/resources/__init__.py
+++ b/instill/resources/__init__.py
@@ -23,7 +23,7 @@ from instill.resources.connector_data import (
     RedisConnector,
     WebsiteConnector,
 )
-from instill.resources.model import GithubModel, HugginfaceModel, Model
+from instill.resources.model import Model
 from instill.resources.operator import (
     Base64Operator,
     ImageOperator,

--- a/instill/resources/model.py
+++ b/instill/resources/model.py
@@ -1,5 +1,4 @@
 # pylint: disable=no-member,wrong-import-position,no-name-in-module
-import time
 from typing import Optional
 
 import instill.protogen.model.model.v1alpha.model_definition_pb2 as model_definition_interface
@@ -20,28 +19,12 @@ class Model(Resource):
         self.client = client
         get_resp = client.model_service.get_model(model_name=name, silent=True)
         if get_resp is None:
-            operation = client.model_service.create_model(
+            model = client.model_service.create_model(
                 name=name,
                 definition=definition,
                 configuration=configuration,
-            ).operation
-            while (
-                client.model_service.get_operation(name=operation.name).operation.done
-                is not True
-            ):
-                time.sleep(1)
-            # TODO: due to state update delay of controller
-            # TODO: should optimize this in model-backend
-            time.sleep(3)
-
-            state = client.model_service.watch_model(model_name=name).state
-            while state == 0:
-                time.sleep(1)
-                state = client.model_service.watch_model(model_name=name).state
-
-            if state == 1:
-                model = client.model_service.get_model(model_name=name).model
-            else:
+            ).model
+            if model is None:
                 raise BaseException("model creation failed")
         else:
             model = get_resp.model
@@ -82,92 +65,9 @@ class Model(Resource):
     def get_definition(self) -> model_definition_interface.ModelDefinition:
         return self.resource.model_definition
 
-    def get_readme(self, silent: bool = False) -> Optional[str]:
-        response = self.client.model_service.get_model_card(
-            self.resource.id,
-            silent=silent,
-        )
-        if response is not None:
-            return response.readme
-        return response
-
-    def get_state(self, silent: bool = False):
-        response = self.client.model_service.watch_model(
-            self.resource.id,
-            silent=silent,
-        )
-        if response is not None:
-            return response.state
-        return response
-
-    def deploy(self, silent: bool = False) -> model_interface.Model.State:
-        self.client.model_service.deploy_model(
-            self.resource.id,
-            silent=silent,
-        )
-        state = self.client.model_service.watch_model(
-            model_name=self.resource.id,
-            silent=silent,
-        ).state
-        while state not in (2, 3):
-            time.sleep(1)
-            state = self.client.model_service.watch_model(
-                model_name=self.resource.id
-            ).state
-        self._update()
-        return state
-
-    def undeploy(self, silent: bool = False) -> model_interface.Model.State:
-        self.client.model_service.undeploy_model(self.resource.id, silent)
-        state = self.client.model_service.watch_model(
-            model_name=self.resource.id, silent=silent
-        ).state
-        while state not in (1, 3):
-            time.sleep(1)
-            state = self.client.model_service.watch_model(
-                model_name=self.resource.id
-            ).state
-        self._update()
-        return state
-
     def delete(self, silent: bool = False):
         if self.resource is not None:
             self.client.model_service.delete_model(
                 self.resource.id,
                 silent=silent,
             )
-
-
-class GithubModel(Model):
-    def __init__(
-        self,
-        client: InstillClient,
-        name: str,
-        model_repo: str,
-        model_tag: str,
-    ) -> None:
-        definition = "model-definitions/github"
-        configuration = {"repository": model_repo, "tag": model_tag}
-        super().__init__(
-            client=client,
-            name=name,
-            definition=definition,
-            configuration=configuration,
-        )
-
-
-class HugginfaceModel(Model):
-    def __init__(
-        self,
-        client: InstillClient,
-        name: str,
-        model_repo: str,
-    ) -> None:
-        configuration = {"repo_id": model_repo}
-        definition = "model-definitions/huggingface"
-        super().__init__(
-            client=client,
-            name=name,
-            definition=definition,
-            configuration=configuration,
-        )

--- a/instill/resources/pipeline.py
+++ b/instill/resources/pipeline.py
@@ -20,15 +20,28 @@ class Pipeline(Resource):
     ) -> None:
         super().__init__()
         self.client = client
-        get_resp = client.pipeline_service.get_pipeline(name=name, silent=True)
-        if get_resp is None:
-            pipeline = client.pipeline_service.create_pipeline(
-                name=name, recipe=recipe
-            ).pipeline
-            if pipeline is None:
-                raise BaseException("pipeline creation failed")
-        else:
-            pipeline = get_resp.pipeline
+        get_resp = None
+        pipeline = None
+        if client.pipeline_service.target_namespace.startswith("users"):
+            get_resp = client.pipeline_service.get_pipeline(name=name, silent=True)
+            if get_resp is None:
+                pipeline = client.pipeline_service.create_pipeline(
+                    name=name, recipe=recipe
+                ).pipeline
+                if pipeline is None:
+                    raise BaseException("pipeline creation failed")
+            else:
+                pipeline = get_resp.pipeline
+        elif client.pipeline_service.target_namespace.startswith("organizations"):
+            get_resp = client.pipeline_service.get_org_pipeline(name=name, silent=True)
+            if get_resp is None:
+                pipeline = client.pipeline_service.create_org_pipeline(
+                    name=name, recipe=recipe
+                ).pipeline
+                if pipeline is None:
+                    raise BaseException("pipeline creation failed")
+            else:
+                pipeline = get_resp.pipeline
 
         self.resource = pipeline
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,5 @@
 # pylint: disable=no-member,unused-import
 import instill.protogen.model.model.v1alpha.model_pb2 as model_interface
-from instill.resources.model import GithubModel
 
 local_model = {
     "model_name": "test1",


### PR DESCRIPTION
Because

- Some client apps has been affected by the breaking changes within API spec, needs to update some part of api abstraction fast to continue supporting those client apps
- breaking changes has not yet all catch up, this will need to be done soon

This commit

- update api spec partially
