### PR TITLE
fix(ray): avoid protogen module name collision with model.py

### DIFF
--- a/instill/__init__.py
+++ b/instill/__init__.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-name-in-module
+# pylint: disable=no-name-in-module,wrong-import-position
 import os
 import sys
 from importlib.metadata import PackageNotFoundError, version
@@ -7,7 +7,16 @@ from instill.utils.logger import Logger
 
 Logger.initialize()
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "protogen"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "protogen"))
+
+# protogen `model` package collides with `model.py`
+# temporarily remove current directory from sys.path
+# and import ray_io
+if "" in sys.path:
+    sys.path.remove("")
+    import instill.helpers.ray_io
+
+    sys.path.insert(0, "")
 
 try:
     __version__ = version("instill-sdk")

--- a/instill/helpers/ray_io.py
+++ b/instill/helpers/ray_io.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member,no-name-in-module, inconsistent-return-statements
+# pylint: disable=no-member,no-name-in-module, inconsistent-return-statements, unused-import
 import base64
 import io
 import re

--- a/instill/resources/__init__.py
+++ b/instill/resources/__init__.py
@@ -1,35 +1,3 @@
-import instill.protogen.common.task.v1alpha.task_pb2 as task
-import instill.protogen.model.model.v1alpha.model_pb2 as model_pb
-import instill.protogen.model.model.v1alpha.task_classification_pb2 as task_classification
-import instill.protogen.model.model.v1alpha.task_detection_pb2 as task_detection
-import instill.protogen.model.model.v1alpha.task_keypoint_pb2 as task_keypoint
-import instill.protogen.model.model.v1alpha.task_ocr_pb2 as task_ocr
-import instill.protogen.model.model.v1alpha.task_semantic_segmentation_pb2 as task_semantic_segmentation
-import instill.protogen.model.model.v1alpha.task_text_generation_pb2 as task_text_generation
-import instill.protogen.model.model.v1alpha.task_text_to_image_pb2 as task_text_to_image
-import instill.protogen.vdp.pipeline.v1beta.pipeline_pb2 as pipeline_pb
-
-# from instill.resources.connector_ai import (
-#     HuggingfaceConnector,
-#     InstillModelConnector,
-#     OpenAIConnector,
-#     StabilityAIConnector,
-# )
-# from instill.resources.connector_blockchain import NumbersConnector
-# from instill.resources.connector_data import (
-#     BigQueryConnector,
-#     GoogleCloudStorageConnector,
-#     GoogleSearchConnector,
-#     PineconeConnector,
-#     RedisConnector,
-#     WebsiteConnector,
-# )
-# from instill.resources.operator import (
-#     Base64Operator,
-#     ImageOperator,
-#     JSONOperator,
-#     TextOperator,
-# )
 from instill.resources.model import Model
 from instill.resources.pipeline import Pipeline
 from instill.resources.schema.helper import populate_default_value


### PR DESCRIPTION
Because

- Our protogen `model` module import name will collide with local `model.py`

This commit

- avoid module name collision by temporarily remove cwd path from `sys.path`
