### PR TITLE
feat(ray): separate sdk installation into another layer

### DIFF
--- a/instill/helpers/cli.py
+++ b/instill/helpers/cli.py
@@ -148,7 +148,6 @@ def build(args):
                 packages_str += p + " "
         for p in DEFAULT_DEPENDENCIES:
             packages_str += p + " "
-        packages_str += f"instill-sdk=={instill_version}"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             shutil.copyfile(
@@ -176,6 +175,8 @@ def build(args):
                 f"PACKAGES={packages_str}",
                 "--build-arg",
                 f"SYSTEM_PACKAGES={system_str}",
+                "--build-arg",
+                f"SDK_VERSION={instill_version}",
                 "--platform",
                 f"linux/{args.target_arch}",
                 "-t",

--- a/instill/helpers/init-templates/Dockerfile
+++ b/instill/helpers/init-templates/Dockerfile
@@ -18,6 +18,9 @@ RUN for package in ${PACKAGES}; do \
     pip install --default-timeout=1000 --no-cache-dir $package; \
     done;
 
+ARG SDK_VERSION
+RUN pip install --default-timeout=1000 --no-cache-dir instill-sdk==${SDK_VERSION}
+
 WORKDIR /home/ray
 COPY --chown=ray:users --exclude=model.py . .
 COPY --chown=ray:users model.py model.py


### PR DESCRIPTION
Because

- Often time `instill-sdk` package is updated while other dependencies version stay the same

This commit

- separate sdk installation into another layer to make the build process more effiecient
