### PR TITLE
fix(ray): revert path injection and rename model file instead

### DIFF
--- a/instill/__init__.py
+++ b/instill/__init__.py
@@ -9,15 +9,6 @@ Logger.initialize()
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "protogen"))
 
-# protogen `model` package collides with `model.py`
-# temporarily remove current directory from sys.path
-# and import ray_io
-if "" in sys.path:
-    sys.path.remove("")
-    import instill.helpers.ray_io
-
-    sys.path.insert(0, "")
-
 try:
     __version__ = version("instill-sdk")
 except PackageNotFoundError:

--- a/instill/helpers/init-templates/Dockerfile
+++ b/instill/helpers/init-templates/Dockerfile
@@ -23,4 +23,4 @@ RUN pip install --default-timeout=1000 --no-cache-dir instill-sdk==${SDK_VERSION
 
 WORKDIR /home/ray
 COPY --chown=ray:users --exclude=model.py . .
-COPY --chown=ray:users model.py model.py
+COPY --chown=ray:users model.py _model.py


### PR DESCRIPTION
Because

- executable path is not always `""`

This commit

- rename conflicting `model.py` file name inside container
