### PR TITLE
feat(build): support local sdk wheel for building model image

### DIFF
--- a/instill/helpers/cli.py
+++ b/instill/helpers/cli.py
@@ -55,16 +55,25 @@ def cli():
         required=False,
     )
     build_parser.add_argument(
+        "-n",
         "--no-cache",
         help="build the image without cache",
         action="store_true",
         required=False,
     )
     build_parser.add_argument(
+        "-a",
         "--target-arch",
         help="target platform architecture for the model image, default to host",
         default=default_platform,
         choices=["arm64", "amd64"],
+        required=False,
+    )
+    build_parser.add_argument(
+        "-w",
+        "--sdk-wheel",
+        help="instill sdk wheel absolute path for debug purpose",
+        default=None,
         required=False,
     )
 
@@ -178,6 +187,12 @@ def build(args):
                 f"{tmpdir}/Dockerfile",
             )
             shutil.copytree(os.getcwd(), tmpdir, dirs_exist_ok=True)
+
+            if args.sdk_wheel is not None:
+                shutil.copyfile(
+                    args.sdk_wheel,
+                    f"{tmpdir}/instill_sdk-{instill_version}dev-py3-none-any.whl",
+                )
 
             target_arch_suffix = "-aarch64" if args.target_arch == "arm64" else ""
 

--- a/instill/helpers/init-templates/Dockerfile
+++ b/instill/helpers/init-templates/Dockerfile
@@ -21,7 +21,11 @@ RUN for package in ${PACKAGES}; do \
 COPY --chown=ray:users --exclude=model.py . .
 
 ARG SDK_VERSION
-RUN pip install --default-timeout=1000 --no-cache-dir instill-sdk==${SDK_VERSION}
+RUN if [ ! -f instill_sdk-${SDK_VERSION}dev-py3-none-any.whl ]; then \
+        pip install --default-timeout=1000 --no-cache-dir instill-sdk==${SDK_VERSION}; \
+    else \
+        pip install instill_sdk-${SDK_VERSION}dev-py3-none-any.whl; \
+    fi;
 
 WORKDIR /home/ray
 COPY --chown=ray:users model.py _model.py


### PR DESCRIPTION
Because

- currently, model image can only install instill-sdk from pypi service, which makes changes must be merged into main branch

->

- with these changes, we can make dist to build local dev wheel and instill build --sdk-wheel {path-to-wheel} to force model image to use dev version sdk, which makes the dev process much easier

This commit

- support local sdk wheel for building model image
