### PR TITLE
feat(artifact): update get_file_catalog input parameter default values

### DIFF
--- a/instill/clients/artifact.py
+++ b/instill/clients/artifact.py
@@ -509,8 +509,8 @@ class ArtifactClient(Client):
         self,
         namespace_id: str,
         catalog_id: str,
-        file_id: str,
-        file_uid: str,
+        file_id: str = "",
+        file_uid: str = "",
         async_enabled: bool = False,
     ) -> file_catalog_interface.GetFileCatalogResponse:
         if async_enabled:


### PR DESCRIPTION
Because

- get_file_catalog file_id and file_uid can allow empty string as input

This commit

- add default value for get_file_catalog input parameters

related changes for documentation at https://github.com/instill-ai/instill.tech/pull/1087