### PR TITLE
fix(dockerfile): revert storing cache dir

### DIFF
--- a/instill/helpers/init-templates/Dockerfile
+++ b/instill/helpers/init-templates/Dockerfile
@@ -15,7 +15,7 @@ RUN for package in ${SYSTEM_PACKAGES}; do \
 
 ARG PACKAGES
 RUN for package in ${PACKAGES}; do \
-    pip install --default-timeout=1000 $package; \
+    pip install --default-timeout=1000 --no-cache-dir $package; \
     done;
 
 COPY --chown=ray:users --exclude=model.py . .


### PR DESCRIPTION
Because

- cache dir will cause significant storage size increase in model image

This commit

- revert storing cache dir
