### PR TITLE
fix(ray): replace user-agent header

### DIFF
--- a/instill/helpers/const.py
+++ b/instill/helpers/const.py
@@ -16,6 +16,11 @@ EMBEDDING_TRUNCATE_NONE = "none"
 EMBEDDING_TRUNCATE_END = "end"
 EMBEDDING_TRUNCATE_START = "start"
 
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+        (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
+}
+
 
 class VisionInput:
     image: Image.Image

--- a/instill/helpers/ray_io.py
+++ b/instill/helpers/ray_io.py
@@ -11,6 +11,7 @@ from PIL import Image
 from starlette.requests import Request
 
 from instill.helpers.const import (
+    HEADERS,
     IMAGE_INPUT_TYPE_BASE64,
     IMAGE_INPUT_TYPE_URL,
     PROMPT_ROLES,
@@ -42,7 +43,7 @@ def base64_to_pil_image(base64_str):
 
 
 def url_to_pil_image(url):
-    resp = requests.get(url, timeout=10)
+    resp = requests.get(url, headers=HEADERS, timeout=10)
     resp.raise_for_status()
     return Image.open(io.BytesIO(resp.content))
 


### PR DESCRIPTION
Because

- `python-request` user-agent header will cause image retrieval to be blocked

This commit

- replace user-agent header
