### PR TITLE
fix(ray): fix misaligned message and image length

### DIFF
--- a/instill/helpers/ray_io.py
+++ b/instill/helpers/ray_io.py
@@ -805,6 +805,7 @@ async def parse_task_chat_to_multimodal_chat_input(
             images.append(imgs)
 
         if messages[0]["role"] != PROMPT_ROLES[-1]:
+            images.insert(0, [])
             messages.insert(
                 0,
                 {


### PR DESCRIPTION
Because

- image list and message list length does not match

This commit

- fix misaligned message and image length
