### PR TITLE
fix(vdp): fix create pipeline input parameters

### DIFF
--- a/instill/clients/pipeline.py
+++ b/instill/clients/pipeline.py
@@ -235,9 +235,17 @@ class PipelineClient(Client):
     def create_pipeline(
         self,
         namespace_id: str,
-        pipeline: pipeline_interface.Pipeline,
+        name: str,
+        description: str,
+        recipe: dict,
         async_enabled: bool = False,
     ) -> pipeline_interface.CreateNamespacePipelineResponse:
+        pipeline = pipeline_interface.Pipeline(
+            id=name,
+            description=description,
+        )
+        pipeline.recipe.update(recipe)
+
         if async_enabled:
             return RequestFactory(
                 method=self.host.async_client.CreateNamespacePipeline,


### PR DESCRIPTION
Because

- some changes are reverted in previous release

This commit

- fix create pipeline input parameters
