### PR TITLE
feat(ray): support shorter downscale config for test models

### DIFF
--- a/instill/helpers/__init__.py
+++ b/instill/helpers/__init__.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-name-in-module
 from instill.helpers.protobufs.ray_pb2 import CallRequest, CallResponse
+from instill.helpers.ray_config import InstillDeployable, instill_deployment
 from instill.helpers.ray_io import (
     construct_custom_output,
     construct_task_chat_output,


### PR DESCRIPTION
Because

- `30` minutes downscale delay is not suitable for testing scenario

This commit

- support shorter downscale config for test models
