### PR TITLE
fix(ray): add -y for apt package installation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.3.1 ; python_version >= "3.9" and python_version < "3.12"
 pygments==2.18.0 ; python_version >= "3.9" and python_version < "3.12"
-jinja2==3.1.5 ; python_version >= "3.9" and python_version < "3.12"
+jinja2==3.1.4 ; python_version >= "3.9" and python_version < "3.12"

--- a/instill/helpers/init-templates/Dockerfile
+++ b/instill/helpers/init-templates/Dockerfile
@@ -10,7 +10,7 @@ RUN sudo apt-get update && sudo apt-get install curl vim -y
 
 ARG SYSTEM_PACKAGES
 RUN for package in ${SYSTEM_PACKAGES}; do \
-    sudo apt-get install $package; \
+    sudo apt-get install -y $package; \
     done;
 
 ARG PACKAGES


### PR DESCRIPTION
Because

- confirmation prompt will break model image building

This commit

- add -y for apt package installation
