### PR TITLE
ci(CODEOWNERS): assign George and Pinglin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @heiruwu @joremysh
+* @GeorgeWilliamStrong @pinglin


### PR DESCRIPTION
Because

- repo owners update

This commit

- update the CODEOWNERS file
