### PR TITLE
chore(ray): build user defined protos in image

### DIFF
--- a/instill/helpers/docker/.dockerignore
+++ b/instill/helpers/docker/.dockerignore
@@ -18,3 +18,6 @@ __pycache__
 
 # Exclude model config file
 instill.yaml
+
+# Exclude Dockerfile
+Dockerfile*

--- a/instill/helpers/docker/Dockerfile
+++ b/instill/helpers/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --default-timeout=1000 $package; \
     done
 
-COPY --chown=ray:users --exclude=model.py . .
+COPY --chown=ray:users . .
 
 ARG INSTILL_PYTHON_SDK_PROJECT_NAME
 ARG INSTILL_PYTHON_SDK_VERSION
@@ -40,4 +40,8 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --default-timeout=1000 instill-sdk==${INSTILL_PYTHON_SDK_VERSION}; \
     fi;
 
-COPY --chown=ray:users model.py _model.py
+# Download protobuf definition from GitHub
+RUN curl -L https://raw.githubusercontent.com/instill-ai/protobufs/1427cfe974daf443987b08a97fe4ff1cd9fcd7c8/model/ray/v1alpha/user_defined.proto -o user_defined.proto
+
+RUN python -m grpc_tools.protoc -I=. --python_out=. --pyi_out=. --grpc_python_out=. ./user_defined.proto
+ENV PYTHONPATH=/home/ray

--- a/instill/helpers/docker/Dockerfile.vllm
+++ b/instill/helpers/docker/Dockerfile.vllm
@@ -75,8 +75,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     done
 
 WORKDIR /home/ray
-COPY --chown=ray:users --exclude=model.py . .
-COPY --chown=ray:users model.py _model.py
+COPY --chown=ray:users . .
 
 ARG INSTILL_PYTHON_SDK_PROJECT_NAME
 ARG INSTILL_PYTHON_SDK_VERSION
@@ -90,3 +89,9 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     fi;
 
 USER ray
+
+# Download protobuf definition from GitHub
+RUN curl -L https://raw.githubusercontent.com/instill-ai/protobufs/1427cfe974daf443987b08a97fe4ff1cd9fcd7c8/model/ray/v1alpha/user_defined.proto -o user_defined.proto
+
+RUN python -m grpc_tools.protoc -I=. --python_out=. --pyi_out=. --grpc_python_out=. ./user_defined.proto
+ENV PYTHONPATH=/home/ray


### PR DESCRIPTION
Because

- Ray runtime_env will [deprecate](https://github.com/ray-project/ray/blob/master/python/ray/runtime_env/runtime_env.py#L396-L400) `container` on 31st July, `image_uri` should be used instead.

This commit

- tackles the coming Ray change. Instead of mounting the gRPC files during runtime, we build the files directly in the image.
- improves the clarity of the Dockerfile for vllm arm64
