### PR TITLE
fix(ray): make non-editable work with dynamic pkg import

### DIFF
--- a/instill/helpers/cli.py
+++ b/instill/helpers/cli.py
@@ -63,7 +63,7 @@ def cli():
     build_parser.add_argument(
         "-a",
         "--target-arch",
-        help="target platform architecture for the model image, default to host",
+        help="target platform architecture for the model image, default to host architecture",
         default=default_platform,
         choices=["arm64", "amd64"],
         required=False,
@@ -298,11 +298,23 @@ def prepare_build_command(args, tmpdir, dockerfile, build_vars):
 
     command.extend(
         [
+            # editable mode
             "--build-arg",
             f"INSTILL_PYTHON_SDK_PROJECT_NAME={instill_python_sdk_project_name}",
+            "--build-arg",
+            (
+                "PYTHONPATH_USER_DEFINED_PROTO=/home/ray/"
+                f"{instill_python_sdk_project_name}/instill/protogen/model/ray/v1alpha"
+            ),
         ]
         if instill_python_sdk_project_name
-        else []
+        else [
+            "--build-arg",
+            (
+                "PYTHONPATH_USER_DEFINED_PROTO=/home/ray/"
+                "anaconda3/lib/python3.11/site-packages/instill/protogen/model/ray/v1alpha"
+            ),
+        ]
     )
 
     return command

--- a/instill/helpers/docker/Dockerfile
+++ b/instill/helpers/docker/Dockerfile
@@ -31,7 +31,7 @@ COPY --chown=ray:users . .
 
 ARG INSTILL_PYTHON_SDK_PROJECT_NAME
 ARG INSTILL_PYTHON_SDK_VERSION
-RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \    
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     if [ ! -z "$INSTILL_PYTHON_SDK_PROJECT_NAME" ]; then \
     pip install -e ${INSTILL_PYTHON_SDK_PROJECT_NAME}; \
     elif [ -f instill_sdk-${INSTILL_PYTHON_SDK_VERSION}dev-py3-none-any.whl ]; then \
@@ -45,4 +45,5 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
 # created in the runtime environment. These objects may depend on this python-sdk.
 # Instead of installing the SDK in the Ray image, we copy
 # the entire SDK to /home/ray and set PYTHONPATH to allow dynamic importing.
-ENV PYTHONPATH=/home/ray/python-sdk/instill/protogen/model/ray/v1alpha
+ARG PYTHONPATH_USER_DEFINED_PROTO
+ENV PYTHONPATH=${PYTHONPATH_USER_DEFINED_PROTO}

--- a/instill/helpers/docker/Dockerfile.vllm
+++ b/instill/helpers/docker/Dockerfile.vllm
@@ -95,4 +95,5 @@ USER ray
 # created in the runtime environment. These objects may depend on this python-sdk.
 # Instead of installing the SDK in the Ray image, we copy
 # the entire SDK to /home/ray and set PYTHONPATH to allow dynamic importing.
-ENV PYTHONPATH=/home/ray/python-sdk/instill/protogen/model/ray/v1alpha
+ARG PYTHONPATH_USER_DEFINED_PROTO
+ENV PYTHONPATH=${PYTHONPATH_USER_DEFINED_PROTO}


### PR DESCRIPTION
Because

- `pip install` will put instill-sdk in the standard anaconda3 package path.

This commit

- make editable and non-editable work together.
